### PR TITLE
feature/enable-cors

### DIFF
--- a/media_management_api/requirements/base.txt
+++ b/media_management_api/requirements/base.txt
@@ -8,3 +8,4 @@ hiredis==0.2.0
 djangorestframework==3.3.1
 markdown==2.6.5
 django-filter==0.11.0
+django-cors-headers==0.11

--- a/media_management_api/settings/aws.py
+++ b/media_management_api/settings/aws.py
@@ -16,5 +16,10 @@ EMAIL_PORT = 587  # Use 587 or 2587 to avoid timeouts when sending mail via Amaz
 EMAIL_HOST_USER = SECURE_SETTINGS.get('email_host_user', '')
 EMAIL_HOST_PASSWORD = SECURE_SETTINGS.get('email_host_password', '')
 
+# CORS heaed
+CORS_ORIGIN_REGEX_WHITELIST = (
+    '^(https?://)?(\w+\.)*harvard\.edu$',
+)
+
 # Configure logging
 dictConfig(LOGGING)

--- a/media_management_api/settings/base.py
+++ b/media_management_api/settings/base.py
@@ -33,12 +33,14 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.admin',
     'rest_framework',
+    'corsheaders',
     'media_service',
 ]
 
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/media_management_api/settings/local.py
+++ b/media_management_api/settings/local.py
@@ -14,6 +14,9 @@ DEBUG_TOOLBAR_CONFIG = {
     'INTERCEPT_REDIRECTS': False,
 }
 
+# CORS headers
+CORS_ORIGIN_ALLOW_ALL = True
+
 # Logging
 
 # Log to console instead of a file when running locally


### PR DESCRIPTION
This PR adds [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) headers so other tools can make client-side requests and access the API. This PR uses [django-cors-headers/](https://github.com/ottoyiu/django-cors-headers/) to add the necessary headers.

@jazahn review?