### PR TITLE
feature/collection-update

### DIFF
--- a/media_service/models.py
+++ b/media_service/models.py
@@ -130,7 +130,7 @@ class Course(BaseModel):
         return "{0}:{1}:{2}".format(self.id, self.lti_context_id, self.title)
 
 class CourseImage(BaseModel, SortOrderModelMixin):
-    course = models.ForeignKey(Course, on_delete=models.CASCADE, related_name='images')
+    course = models.ForeignKey(Course, on_delete=models.CASCADE)
     owner = models.ForeignKey(UserProfile, null=True)
     media_store = models.ForeignKey(MediaStore, null=True, on_delete=models.SET_NULL)
     is_upload = models.BooleanField(default=True, null=False)
@@ -177,7 +177,7 @@ class CourseImage(BaseModel, SortOrderModelMixin):
 class Collection(BaseModel, SortOrderModelMixin):
     title = models.CharField(max_length=255)
     description = models.TextField(blank=True)
-    course = models.ForeignKey(Course, on_delete=models.CASCADE, related_name='collections')
+    course = models.ForeignKey(Course, on_delete=models.CASCADE)
     sort_order = models.IntegerField(default=0)
 
     class Meta:
@@ -198,8 +198,8 @@ class Collection(BaseModel, SortOrderModelMixin):
         return collections
 
 class CollectionImage(BaseModel, SortOrderModelMixin):
-    collection = models.ForeignKey(Collection, on_delete=models.CASCADE, related_name='images')
-    course_image = models.ForeignKey(CourseImage, on_delete=models.CASCADE, related_name='collections')
+    collection = models.ForeignKey(Collection, on_delete=models.CASCADE)
+    course_image = models.ForeignKey(CourseImage, on_delete=models.CASCADE)
     sort_order = models.IntegerField(default=0)
 
     class Meta:

--- a/media_service/serializers.py
+++ b/media_service/serializers.py
@@ -100,6 +100,23 @@ class CollectionSerializer(serializers.HyperlinkedModelSerializer):
         )
         collection.save()
         return collection
+    
+    def update(self, instance, validated_data):
+        request = self.context['request']
+        if not validated_data:
+            return instance
+        if 'title' in validated_data:
+            instance.title = validated_data['title']
+        if 'description' in validated_data:
+            instance.description = validated_data['description']
+        if 'course_image_ids' in validated_data:
+            course_image_ids = validated_data['course_image_ids']
+            CollectionImage.objects.filter(collection__pk=instance.pk).delete()
+            for course_image_id in course_image_ids:
+                CollectionImage(collection=instance.pk, course_image=course_image_id).save()
+        instance.save()
+        return instance
+    
 
     def to_representation(self, instance):
         data = super(CollectionSerializer, self).to_representation(instance)


### PR DESCRIPTION
Implementing ```update()``` method for collections endpoint that permits the client to optionally update the associated course images along with attributes of the collection itself.

Example:
```
PUT http://localhost:8000/collections/1
{
    "course_id": 1, 
    "title": "Scrambled Eggs Super!", 
    "course_image_ids": [1,4] 
}
```
