### PR TITLE
Feature/query performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ sqlnet.log
 *.pot
 .vagrant
 *.sqlite3
-pyenv
+/pyenv
+/rest_framework
 # Generated files
 secure.py
 gunicorn.py

--- a/media_management_api/middleware.py
+++ b/media_management_api/middleware.py
@@ -1,0 +1,21 @@
+from django.db import connection
+from django.utils.log import getLogger
+
+logger = getLogger(__name__)
+
+class QueryCountDebugMiddleware(object):
+    def process_response(self, request, response):
+        if response.status_code == 200:
+            total_time = 0
+            for query in connection.queries:
+                query_time = query.get('time')
+                if query_time is None:
+                    # django-debug-toolbar monkeypatches the connection
+                    # cursor wrapper and adds extra information in each
+                    # item in connection.queries. The query time is stored
+                    # under the key "duration" rather than "time" and is
+                    # in milliseconds, not seconds.
+                    query_time = query.get('duration', 0) / 1000
+                total_time += float(query_time)
+            logger.debug('%s queries run, total %s seconds' % (len(connection.queries), total_time))
+        return response

--- a/media_management_api/settings/base.py
+++ b/media_management_api/settings/base.py
@@ -50,6 +50,9 @@ MIDDLEWARE_CLASSES = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+if DEBUG:
+    MIDDLEWARE_CLASSES = ['media_management_api.middleware.QueryCountDebugMiddleware'] + MIDDLEWARE_CLASSES
+
 # Authentication
 
 # Django defaults are below, but will need to be customized if using something
@@ -213,15 +216,25 @@ LOGGING = {
         # Make sure that propagate is False so that the root logger doesn't get involved
         # after an app logger handles a log message.
         'django': {
-            'handlers': ['console'],
+            'handlers': ['default', 'console'],
             'level': 'INFO',
             'propagate': True,
         },
         'django.db': {
-            'handlers': ['console'],
-            'level': 'INFO', # Set to DEBUG to see SQL output
+            'handlers': ['default', 'console'],
+            'level': 'DEBUG', # Set to DEBUG to see SQL output
             'propagate': True,
-        }
+        },
+        'media_management_api': {
+            'handlers': ['default', 'console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'media_service': {
+            'handlers': ['default', 'console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
     },
 }
 

--- a/media_service/serializers.py
+++ b/media_service/serializers.py
@@ -62,21 +62,23 @@ class CollectionImageSerializer(serializers.HyperlinkedModelSerializer):
 
     def to_representation(self, instance):
         data =  super(CollectionImageSerializer, self).to_representation(instance)
+        course_image = instance.course_image
         data.update({
             "type": 'collectionimages',
             "url": reverse('collectionimages-detail', kwargs={'pk': instance.pk}, request=self.context['request']),
-            "course_image_id": instance.course_image.id,
-            "title": instance.course_image.title,
-            "description": instance.course_image.description,
-            "upload_file_name": instance.course_image.upload_file_name,
-            "is_upload": instance.course_image.is_upload,
+            "course_image_id": course_image.id,
+            "title": course_image.title,
+            "description": course_image.description,
+            "upload_file_name": course_image.upload_file_name,
+            "is_upload": course_image.is_upload,
         })
-        data.update(course_image_to_representation(instance.course_image))
+        data.update(course_image_to_representation(course_image))
         return data
 
 class CollectionCourseImageIdsField(serializers.Field):
     def to_representation(self, obj):
-        return obj.images.values_list('course_image__pk', flat=True)
+        course_image_ids = [collection_image.course_image_id for collection_image in obj.images.all()]
+        return course_image_ids
 
     def to_internal_value(self, data):
         course_pk = self.parent.instance.course.pk

--- a/media_service/serializers.py
+++ b/media_service/serializers.py
@@ -132,7 +132,7 @@ class CollectionSerializer(serializers.HyperlinkedModelSerializer):
             for course_image_id in course_image_ids:
                 CollectionImage.objects.create(collection_id=instance.pk, course_image_id=course_image_id)
         instance.save()
-        return instance
+        return Collection.objects.get(pk=instance.pk) # Get object fresh from DB to avoid cache problems
 
     def to_representation(self, instance):
         data = super(CollectionSerializer, self).to_representation(instance)

--- a/media_service/serializers.py
+++ b/media_service/serializers.py
@@ -173,6 +173,7 @@ class CourseImageSerializer(serializers.HyperlinkedModelSerializer):
         result = self.handle_file_upload(request)
         instance.media_store = result['media_store']
         instance.upload_file_name = result['upload_file_name']
+        instance.is_upload = result['is_upload']
         instance.save()
         return instance
 


### PR DESCRIPTION
This PR improves the query performance of the ```/courses/{pk}``` and ```/collections/{pk}``` endpoints. Since these endpoints are probably going to see a majority of the *GET* requests, these are probably the most important to optimize. We can optimize others as needed.

The issue with those endpoints is that they are generating [N+1 queries](http://stackoverflow.com/questions/97197/what-is-the-n1-selects-issue) when they add the related *images*, *collections*, etc. The serializers aren't quite smart enough to do the necessary JOINs or prefetching by default, so this PR uses `select_related()` and `prefetch_related()` to do that. It also refactors the code to make sure that the views are using the `get_queryset()` and `get_object()` methods to use the cached queryset that is defined on the class.

@jazahn Can you review this?