### PR TITLE
feature/auth

### DIFF
--- a/media_auth/admin.py
+++ b/media_auth/admin.py
@@ -1,0 +1,17 @@
+from django.contrib import admin
+from .models import Application, Token
+
+class TokensInline(admin.StackedInline):
+    extra = 0
+    verbose_name = 'Token'
+    model = Token
+
+class ApplicationAdmin(admin.ModelAdmin):
+    list_display = ('id', 'key', 'description', 'created')
+    inlines = (TokensInline,)
+
+class TokenAdmin(admin.ModelAdmin):
+    list_display = ('id', 'application', 'user_profile', 'key', 'scope', 'created')
+
+admin.site.register(Token, TokenAdmin)
+admin.site.register(Application, ApplicationAdmin)

--- a/media_auth/admin.py
+++ b/media_auth/admin.py
@@ -7,7 +7,7 @@ class TokensInline(admin.StackedInline):
     model = Token
 
 class ApplicationAdmin(admin.ModelAdmin):
-    list_display = ('id', 'key', 'description', 'created')
+    list_display = ('id', 'client_id', 'client_secret', 'description', 'created')
     inlines = (TokensInline,)
 
 class TokenAdmin(admin.ModelAdmin):

--- a/media_auth/authentication.py
+++ b/media_auth/authentication.py
@@ -5,7 +5,7 @@ from . import services
 
 class CustomTokenAuthentication(authentication.BaseAuthentication):
     def authenticate_header(self, request):
-        return 'Bearer'
+        return 'Bearer realm="api"'
     
     def authenticate(self, request):
         access_token = services.get_access_token_from_request(request)

--- a/media_auth/authentication.py
+++ b/media_auth/authentication.py
@@ -1,22 +1,28 @@
 from django.contrib.auth.models import User
 from rest_framework import authentication
 from rest_framework import exceptions
-from . import services
+from .exceptions import InvalidTokenError
+from .services import get_access_token_from_request, assert_token_valid, get_token
+
+import logging
+logger = logging.getLogger(__name__)
 
 class CustomTokenAuthentication(authentication.BaseAuthentication):
     def authenticate_header(self, request):
         return 'Bearer realm="api"'
     
     def authenticate(self, request):
-        access_token = services.get_access_token_from_request(request)
+        access_token = get_access_token_from_request(request)
         if not access_token:
+            logger.debug("No access token found in request")
             return None
 
         try:
-            services.is_token_valid(access_token, raise_exception=True)
-            token = services.get_token(access_token)
+            assert_token_valid(access_token)
+            token = get_token(access_token)
             user = token.user_profile.user
-        except services.InvalidTokenError as e:
+        except InvalidTokenError as e:
+            logger.debug(str(e))
             raise exceptions.AuthenticationFailed(str(e))
 
         return (user, None)

--- a/media_auth/authentication.py
+++ b/media_auth/authentication.py
@@ -1,0 +1,22 @@
+from django.contrib.auth.models import User
+from rest_framework import authentication
+from rest_framework import exceptions
+from . import services
+
+class CustomTokenAuthentication(authentication.BaseAuthentication):
+    def authenticate_header(self, request):
+        return 'Bearer'
+    
+    def authenticate(self, request):
+        access_token = services.get_access_token_from_request(request)
+        if not access_token:
+            return None
+
+        try:
+            services.is_token_valid(access_token, raise_exception=True)
+            token = services.get_token(access_token)
+            user = token.user_profile.user
+        except services.InvalidTokenError as e:
+            raise exceptions.AuthenticationFailed(str(e))
+
+        return (user, None)

--- a/media_auth/authentication.py
+++ b/media_auth/authentication.py
@@ -14,7 +14,6 @@ class CustomTokenAuthentication(authentication.BaseAuthentication):
     def authenticate(self, request):
         access_token = get_access_token_from_request(request)
         if not access_token:
-            logger.debug("No access token found in request")
             return None
 
         try:

--- a/media_auth/authentication.py
+++ b/media_auth/authentication.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 class CustomTokenAuthentication(authentication.BaseAuthentication):
     def authenticate_header(self, request):
-        return 'Bearer realm="api"'
+        return 'Token '
     
     def authenticate(self, request):
         access_token = get_access_token_from_request(request)

--- a/media_auth/exceptions.py
+++ b/media_auth/exceptions.py
@@ -1,0 +1,18 @@
+import json
+
+class MediaAuthException(Exception):
+    def __init__(self, *args):
+        super(MediaAuthException, self).__init__(*args)
+        self.msg = args[0]
+    
+    def as_json(self):
+        return json.dumps({"error": self.msg})
+    
+class InvalidApplicationError(MediaAuthException):
+    pass
+
+class InvalidTokenError(MediaAuthException):
+    pass
+
+class InvalidScopeError(MediaAuthException):
+    pass

--- a/media_auth/filters.py
+++ b/media_auth/filters.py
@@ -1,0 +1,32 @@
+from .services import get_scope_from_request
+
+import logging
+logger = logging.getLogger(__name__)
+
+class BaseEndpointFilter(object):
+    filter_key = "pk__in"
+    def __init__(self, view):
+        self.view = view
+        self.scope = get_scope_from_request(view.request)
+
+    def filter_queryset(self, queryset):
+        if self.scope is None:
+            return queryset
+        if self.scope['object'] == '*':
+            return queryset
+        object_ids = self.scope['object'].split(',')
+        filters = {self.filter_key:object_ids}
+        logger.debug("Filtering queryset with %s" % filters)
+        return queryset.filter(**filters)
+
+class CourseEndpointFilter(BaseEndpointFilter):
+    filter_key = "pk__in"
+
+class CollectionEndpointFilter(BaseEndpointFilter):
+    filter_key = "course__pk__in"
+        
+class ResourceEndpointFilter(BaseEndpointFilter):
+    filter_key = "course__pk__in"
+
+class CollectionResourceEndpointPermission(BaseEndpointFilter):
+    filter_key = "collection__course__pk__in"

--- a/media_auth/migrations/0001_initial.py
+++ b/media_auth/migrations/0001_initial.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('media_service', '0002_auto_20160130_1747'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Application',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('code', models.CharField(unique=True, max_length=40, blank=True)),
+                ('description', models.CharField(max_length=1024)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('updated', models.DateTimeField(auto_now=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Token',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('key', models.CharField(max_length=40)),
+                ('scope', models.CharField(max_length=1024, blank=True)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('application', models.ForeignKey(related_name='user_tokens', to='media_auth.Application')),
+                ('user_profile', models.ForeignKey(related_name='user_tokens', to='media_service.UserProfile')),
+            ],
+        ),
+    ]

--- a/media_auth/migrations/0002_auto_20160130_1907.py
+++ b/media_auth/migrations/0002_auto_20160130_1907.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('media_auth', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='application',
+            old_name='code',
+            new_name='key',
+        ),
+    ]

--- a/media_auth/migrations/0003_auto_20160201_1644.py
+++ b/media_auth/migrations/0003_auto_20160201_1644.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('media_auth', '0002_auto_20160130_1907'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='application',
+            options={'ordering': ['client_id'], 'verbose_name': 'application', 'verbose_name_plural': 'applications'},
+        ),
+        migrations.AlterModelOptions(
+            name='token',
+            options={'ordering': ['-created'], 'verbose_name': 'token', 'verbose_name_plural': 'tokens'},
+        ),
+        migrations.RemoveField(
+            model_name='application',
+            name='key',
+        ),
+        migrations.AddField(
+            model_name='application',
+            name='client_id',
+            field=models.CharField(default='localhost', unique=True, max_length=20),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='application',
+            name='client_secret',
+            field=models.CharField(max_length=40, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='application',
+            name='description',
+            field=models.CharField(max_length=1024, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='token',
+            name='key',
+            field=models.CharField(unique=True, max_length=140),
+        ),
+    ]

--- a/media_auth/models.py
+++ b/media_auth/models.py
@@ -1,0 +1,32 @@
+from django.db import models
+from django.db.models import signals
+from media_service.models import UserProfile
+import uuid
+import hashlib
+import logging
+
+logger = logging.getLogger(__name__)
+
+class Application(models.Model):
+    key = models.CharField(max_length=40, unique=True, blank=True)
+    description = models.CharField(max_length=1024, blank=False)
+    created = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
+
+class Token(models.Model):
+    key = models.CharField(max_length=40, unique=True, blank=False)
+    scope = models.CharField(max_length=1024, blank=True)
+    created = models.DateTimeField(auto_now_add=True)
+    user_profile = models.ForeignKey(UserProfile, on_delete=models.CASCADE, related_name="user_tokens")
+    application = models.ForeignKey(Application, on_delete=models.CASCADE, related_name='user_tokens')
+
+def create_instance_key(sender, instance, **kwargs):
+    if not instance.key:
+        logger.debug("Creating key for sender=%s instance=%s" % (sender, instance))
+        m = hashlib.sha1()
+        m.update(str(instance.id) + str(uuid.uuid4().get_hex().upper()))
+        instance.key = m.hexdigest()
+        instance.save(update_fields=['key'])
+    
+signals.post_save.connect(create_instance_key, sender=Application)
+signals.post_save.connect(create_instance_key, sender=Token)

--- a/media_auth/models.py
+++ b/media_auth/models.py
@@ -1,32 +1,58 @@
 from django.db import models
 from django.db.models import signals
 from media_service.models import UserProfile
-import uuid
+
+import os
+import base64
+import struct
 import hashlib
 import logging
 
 logger = logging.getLogger(__name__)
 
 class Application(models.Model):
-    key = models.CharField(max_length=40, unique=True, blank=True)
-    description = models.CharField(max_length=1024, blank=False)
+    client_id = models.CharField(max_length=20, unique=True, blank=False)
+    client_secret = models.CharField(max_length=40, blank=True)
+    description = models.CharField(max_length=1024, blank=True)
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
 
+    class Meta:
+        verbose_name = 'application'
+        verbose_name_plural = 'applications'
+        ordering = ["client_id"]
+
 class Token(models.Model):
-    key = models.CharField(max_length=40, unique=True, blank=False)
+    key = models.CharField(max_length=80, unique=True, blank=False)
     scope = models.CharField(max_length=1024, blank=True)
     created = models.DateTimeField(auto_now_add=True)
     user_profile = models.ForeignKey(UserProfile, on_delete=models.CASCADE, related_name="user_tokens")
     application = models.ForeignKey(Application, on_delete=models.CASCADE, related_name='user_tokens')
-
-def create_instance_key(sender, instance, **kwargs):
-    if not instance.key:
-        logger.debug("Creating key for sender=%s instance=%s" % (sender, instance))
-        m = hashlib.sha1()
-        m.update(str(instance.id) + str(uuid.uuid4().get_hex().upper()))
-        instance.key = m.hexdigest()
-        instance.save(update_fields=['key'])
     
-signals.post_save.connect(create_instance_key, sender=Application)
-signals.post_save.connect(create_instance_key, sender=Token)
+    class Meta:
+        verbose_name = 'token'
+        verbose_name_plural = 'tokens'
+        ordering = ["-created"]
+
+def create_token_key(sender, instance, **kwargs):
+    if not instance.key:
+        m = hashlib.sha1()
+        m.update(os.urandom(4096))
+        digest_encoded = base64.urlsafe_b64encode(m.digest()).strip("=\n")
+        pk_encoded = base64.urlsafe_b64encode(struct.pack('I', int(instance.pk))).strip("=\n")
+        token = "{digest}{pk}".format(digest=digest_encoded, pk=pk_encoded).lower()
+        instance.key = token
+        instance.save(update_fields=['key'])
+        logger.debug("Creating token key for sender=%s instance=%s token=%s" % (sender, instance, token))
+
+def create_client_secret(sender, instance, **kwargs):
+    if not instance.client_secret:
+        m = hashlib.sha1()
+        m.update(os.urandom(4096))
+        client_secret = m.hexdigest()
+        instance.client_secret = client_secret
+        instance.save(update_fields=['client_secret'])
+        logger.debug("Created client secret for sender=%s instance=%s client_secret=%s" % (sender, instance, client_secret))
+
+signals.post_save.connect(create_client_secret, sender=Application)
+signals.post_save.connect(create_token_key, sender=Token)

--- a/media_auth/permissions.py
+++ b/media_auth/permissions.py
@@ -1,0 +1,109 @@
+from rest_framework.permissions import BasePermission
+from .services import get_scope_from_request
+
+import logging
+logger = logging.getLogger(__name__)
+
+READ_ONLY_METHODS = ('GET', 'HEAD', 'OPTIONS')
+SCOPE_READ = "read"
+SCOPE_WRITE = "write"
+
+class BaseScopePermission(BasePermission):
+    SCOPE = None
+    LOADED_SCOPE = False
+
+    def __init__(self, *args, **kwargs):
+        super(BaseScopePermission, self).__init__(*args, **kwargs)
+    
+    def has_permission(self, request, view):
+        '''
+        Implements has_permission().
+        '''
+        scope = self.get_scope_from_request(request)
+        if scope is None:
+            return True
+
+        has_perm = self.has_scope_method_perm(request, view)
+        logger.debug("has_permission:%s" % has_perm)
+        return has_perm
+
+    def has_object_permission(self, request, view, obj):
+        '''
+        Implements has_object_permission().
+        '''
+        scope = self.get_scope_from_request(request)
+        if scope is None:
+            return True
+
+        has_method_perm = self.has_scope_method_perm(request, view)
+        has_target_perm = self.has_scope_target_perm(request, view)
+        has_object_perm = self.has_scope_object_perm(request, view, obj)
+        
+        has_perm = (has_method_perm and has_target_perm and has_object_perm)
+        logger.debug("has_object_permission:%s (%s & %s & %s) scope:%s " % (has_perm, has_method_perm, has_target_perm, has_object_perm, scope))
+        
+        return has_perm
+
+    def has_scope_method_perm(self, request, view):
+        '''
+        Utility method to check the request method type against the
+        scope's permission (read or write).
+        '''
+        scope = self.get_scope_from_request(request)
+        scope_perm = scope['permission']
+        has_perm = False
+        if scope_perm == SCOPE_WRITE:
+            has_perm = True
+        elif scope_perm == SCOPE_READ:
+            has_perm = request.method in READ_ONLY_METHODS
+        else:
+            has_perm = False
+        return has_perm
+
+    def has_scope_target_perm(self, request, view):
+        scope = self.get_scope_from_request(request)
+        return scope['target'] == 'course'
+    
+    def has_scope_object_perm(self, request, view, obj):
+        scope = self.get_scope_from_request(request)
+        return scope['object'] == '*'
+    
+    def get_scope_from_request(self, request):
+        cls = BaseScopePermission
+        if not cls.LOADED_SCOPE:
+            cls.scope = get_scope_from_request(request)
+            cls.LOADED_SCOPE = True
+        return cls.scope
+
+class CourseEndpointPermission(BaseScopePermission):
+    """
+    The request is authorized by the token scope.
+    """
+    def has_scope_object_perm(self, request, view, obj):
+        scope = self.get_scope_from_request(request)
+        has_perm = super(CourseEndpointPermission, self).has_scope_object_perm(request, view, obj)
+        return has_perm or (str(scope['object']) == str(obj.pk))
+
+class CollectionEndpointPermission(BaseScopePermission):
+    """
+    The request is authorized by the token scope.
+    """
+    def has_scope_object_perm(self, request, view, obj):
+        scope = self.get_scope_from_request(request)
+        has_perm = super(CollectionEndpointPermission, self).has_scope_object_perm(request, view, obj)
+        return has_perm or (str(scope['object']) == str(obj.course.pk))
+
+class ResourceEndpointPermission(CollectionEndpointPermission):
+    """
+    The request is authorized by the token scope.
+    """
+    pass
+
+class CollectionResourceEndpointPermission(BaseScopePermission):
+    """
+    The request is authorized by the token scope.
+    """
+    def has_scope_object_perm(self, request, view, obj):
+        scope = self.get_scope_from_request(request)
+        has_perm = super(CollectionResourceEndpointPermission, self).has_scope_object_perm(request, view, obj)
+        return has_perm or (str(scope['object']) == str(obj.collection.course.pk))

--- a/media_auth/permissions.py
+++ b/media_auth/permissions.py
@@ -13,17 +13,27 @@ class BaseScopePermission(BasePermission):
         super(BaseScopePermission, self).__init__(*args, **kwargs)
         self.scope = None
         self.loaded_scope = False
+        self.auth_required = True
+    
+    def is_authenticated(self, request, view):
+        return request.user and request.user.is_authenticated()
+    
+    def is_authenticated_or_read_only(self, request, view):
+        return (request.method in READ_ONLY_METHODS or (request.user and request.user.is_authenticated()))
     
     def has_permission(self, request, view):
         '''
         Implements has_permission().
         '''
+        if self.auth_required and not self.is_authenticated(request, view):
+            return False
+
         scope = self.get_scope_from_request(request)
         logger.debug("has_permission scope:%s" % scope)
         if scope is None:
             return True
 
-        has_perm = self.has_scope_method_perm(request, view)
+        has_perm = self.has_scope_method_perm(request, view, scope)
         logger.debug("has_permission:%s" % has_perm)
         return has_perm
 
@@ -31,26 +41,28 @@ class BaseScopePermission(BasePermission):
         '''
         Implements has_object_permission().
         '''
+        if self.auth_required and not self.is_authenticated(request, view):
+            return False
+
         scope = self.get_scope_from_request(request)
         logger.debug("has_object_permission scope:%s" % scope)
         if scope is None:
             return True
 
-        has_method_perm = self.has_scope_method_perm(request, view)
-        has_target_perm = self.has_scope_target_perm(request, view)
-        has_object_perm = self.has_scope_object_perm(request, view, obj)
+        has_method_perm = self.has_scope_method_perm(request, view, scope)
+        has_target_perm = self.has_scope_target_perm(request, view, scope)
+        has_object_perm = self.has_scope_object_perm(request, view, obj, scope)
         
         has_perm = (has_method_perm and has_target_perm and has_object_perm)
         logger.debug("has_object_permission:%s (%s & %s & %s)" % (has_perm, has_method_perm, has_target_perm, has_object_perm))
         
         return has_perm
 
-    def has_scope_method_perm(self, request, view):
+    def has_scope_method_perm(self, request, view, scope):
         '''
         Utility method to check the request method type against the
         scope's permission (read or write).
         '''
-        scope = self.get_scope_from_request(request)
         scope_perm = scope['permission']
         has_perm = False
         if scope_perm == SCOPE_WRITE:
@@ -61,12 +73,10 @@ class BaseScopePermission(BasePermission):
             has_perm = False
         return has_perm
 
-    def has_scope_target_perm(self, request, view):
-        scope = self.get_scope_from_request(request)
+    def has_scope_target_perm(self, request, view, scope):
         return scope['target'] == 'course'
     
-    def has_scope_object_perm(self, request, view, obj):
-        scope = self.get_scope_from_request(request)
+    def has_scope_object_perm(self, request, view, obj, scope):
         return scope['object'] == '*'
     
     def get_scope_from_request(self, request):
@@ -80,44 +90,77 @@ class CourseEndpointPermission(BaseScopePermission):
     The request is authorized by the token scope.
     """
     def has_permission(self, request, view):
-        scope = self.get_scope_from_request(request)
-        if scope is None:
+        # Special case: allow *all* for manifests
+        action = view.action_map.get(request.method.lower())
+        if action == "manifests":
             return True
 
         has_perm = super(CourseEndpointPermission, self).has_permission(request, view)
-        
-        # Special case for creating a new course
-        action = view.action_map.get(request.method.lower())
-        if action == "create":
-            has_perm = has_perm and (scope['object'] == '*')
+        scope = self.get_scope_from_request(request)
+        if scope is None:
+            return has_perm
+        else:
+            # Special case: ensure that when creating a course, the scope object is
+            # set to the wildcard.
+            action = view.action_map.get(request.method.lower())
+            if action == "create":
+                has_perm = has_perm and (scope['object'] == '*')
 
         return has_perm
+    
+    def has_object_permission(self, request, view, obj):
+        # Special case: allow *all* for manifests
+        action = view.action_map.get(request.method.lower())
+        if action == "manifests":
+            return True
+
+        has_perm = super(CourseEndpointPermission, self).has_object_permission(request, view, obj)
+        return has_perm
         
-    def has_scope_object_perm(self, request, view, obj):
-        scope = self.get_scope_from_request(request)
-        has_perm = super(CourseEndpointPermission, self).has_scope_object_perm(request, view, obj)
+    def has_scope_object_perm(self, request, view, obj, scope):
+        has_perm = super(CourseEndpointPermission, self).has_scope_object_perm(request, view, obj, scope)
         return has_perm or (str(scope['object']) == str(obj.pk))
 
 class CollectionEndpointPermission(BaseScopePermission):
     """
     The request is authorized by the token scope.
     """
-    def has_scope_object_perm(self, request, view, obj):
-        scope = self.get_scope_from_request(request)
-        has_perm = super(CollectionEndpointPermission, self).has_scope_object_perm(request, view, obj)
+    def has_permission(self, request, view):
+        # Special case: allow *all* for manifest
+        if hasattr(view, 'action_map'):
+            action = view.action_map.get(request.method.lower())
+            if action == "manifest":
+                return True
+
+        has_perm = super(CollectionEndpointPermission, self).has_permission(request, view)
+        return has_perm
+
+    def has_object_permission(self, request, view, obj):
+        # Special case: allow *all* for manifest
+        if hasattr(view, 'action_map'):
+            action = view.action_map.get(request.method.lower())
+            if action == "manifest":
+                return True
+
+        has_perm = super(CollectionEndpointPermission, self).has_object_permission(request, view, obj)
+        return has_perm
+
+    def has_scope_object_perm(self, request, view, obj, scope):
+        has_perm = super(CollectionEndpointPermission, self).has_scope_object_perm(request, view, obj, scope)
         return has_perm or (str(scope['object']) == str(obj.course.pk))
 
-class ResourceEndpointPermission(CollectionEndpointPermission):
+class ResourceEndpointPermission(BaseScopePermission):
     """
     The request is authorized by the token scope.
     """
-    pass
+    def has_scope_object_perm(self, request, view, obj, scope):
+        has_perm = super(CollectionEndpointPermission, self).has_scope_object_perm(request, view, obj, scope)
+        return has_perm or (str(scope['object']) == str(obj.course.pk))
 
 class CollectionResourceEndpointPermission(BaseScopePermission):
     """
     The request is authorized by the token scope.
     """
-    def has_scope_object_perm(self, request, view, obj):
-        scope = self.get_scope_from_request(request)
-        has_perm = super(CollectionResourceEndpointPermission, self).has_scope_object_perm(request, view, obj)
+    def has_scope_object_perm(self, request, view, obj, scope):
+        has_perm = super(CollectionResourceEndpointPermission, self).has_scope_object_perm(request, view, obj, scope)
         return has_perm or (str(scope['object']) == str(obj.collection.course.pk))

--- a/media_auth/permissions.py
+++ b/media_auth/permissions.py
@@ -81,6 +81,9 @@ class CourseEndpointPermission(BaseScopePermission):
     """
     def has_permission(self, request, view):
         scope = self.get_scope_from_request(request)
+        if scope is None:
+            return True
+
         has_perm = super(CourseEndpointPermission, self).has_permission(request, view)
         
         # Special case for creating a new course

--- a/media_auth/services.py
+++ b/media_auth/services.py
@@ -9,7 +9,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-TOKEN_EXPIRE = {"minutes": 1}
+TOKEN_EXPIRE = {"hours": 24}
 
 class InvalidApplicationError(Exception):
     pass
@@ -57,8 +57,8 @@ def create_token(data):
     logger.debug("Created token: %s" % result)
     return result
 
-def get_token(token_key):
-    return Token.objects.get(key=token_key)
+def get_token(access_token):
+    return Token.objects.get(key=access_token)
 
 def get_or_create_user(user_id):
     user_profiles = UserProfile.objects.filter(sis_user_id=user_id)
@@ -74,20 +74,20 @@ def get_or_create_user(user_id):
         user_profile.save()
     return user_profile.user
 
-def is_token_valid(token, raise_excetion=False):
+def is_token_valid(token, raise_exception=False):
     return is_token_expired(token, raise_exception=raise_exception)
 
 def is_token_expired(token, raise_exception=False):
     if isinstance(token, Token):
-        token_key = token.key
+        access_token = token.key
     else:
-        token_key = token
+        access_token = token
 
     try:
-        token = Token.objects.get(key=token_key)
+        token = Token.objects.get(key=access_token)
     except Token.DoesNotExist:
         if raise_exception:
-            raise InvalidTokenError("No token exists with key %s" % token_key)
+            raise InvalidTokenError("No such token: %s" % access_token)
         return True
 
     created = token.created
@@ -109,15 +109,15 @@ def is_valid_application(application_key, raise_exception=False):
         return False
     return True
 
-def destroy_token(token_key):
+def destroy_token(access_token):
     try:
-        Token.objects.get(key=token_key).delete()
+        Token.objects.get(key=access_token).delete()
     except:
         return True
     return True
 
 def get_access_token_from_request(request):
-    authorization = request.META.get('AUTHORIZATION', '')
+    authorization = request.META.get('HTTP_AUTHORIZATION', '')
     access_token = None
     if authorization.lower().startswith("bearer "):
         access_token = authorization.split(" ", 2)[1]

--- a/media_auth/services.py
+++ b/media_auth/services.py
@@ -61,7 +61,7 @@ def obtain_token(data):
     result = {
         "access_token": token.key,
         "scope": token.scope,
-        "created": token.created.isoformat(),
+        "expires": TOKEN_EXPIRE.copy(),
     }
     logger.debug("Created token: %s" % result)
     return result

--- a/media_auth/services.py
+++ b/media_auth/services.py
@@ -47,7 +47,7 @@ def create_token(data):
         "user_profile": user.profile,
         "application": application
     }
-    recent_tokens = Token.objects.filter(**token_attrs).order_by('created')[0:1]
+    recent_tokens = Token.objects.filter(**token_attrs).order_by('-created')[0:1]
     if len(recent_tokens) == 0 or is_token_expired(recent_tokens[0]):
         token = Token(**token_attrs)
         token.save()

--- a/media_auth/services.py
+++ b/media_auth/services.py
@@ -81,7 +81,7 @@ def get_or_create_user(user_id):
     return user_profile.user
 
 def is_token_valid(token, raise_exception=False):
-    return is_token_expired(token, raise_exception=raise_exception)
+    return not is_token_expired(token, raise_exception=raise_exception)
 
 def is_token_expired(token, raise_exception=False):
     if isinstance(token, Token):

--- a/media_auth/services.py
+++ b/media_auth/services.py
@@ -21,7 +21,7 @@ TOKEN_EXPIRE = {"minutes": 15}
 #   read:course:*       write:course:*
 #   read:course:1       write:course:1
 #   read:course:1,2,3   write:course:1,2,3
-SCOPE_PATTERN = r'^(?P<permission>read|write):(?P<target>course):(?P<object>\*|\d|(?:(?:\d,)+\d))$'
+SCOPE_PATTERN = r'^(?P<permission>read|write):(?P<target>course):(?P<object>\*|\d+|(?:(?:\d+,)+\d+))$'
 
 
 def obtain_token(data):
@@ -138,9 +138,20 @@ def get_access_token_from_request(request):
 
 def get_scope_from_request(request):
     access_token = get_access_token_from_request(request)
-    try:
-        token = get_token(access_token)
-    except:
+    if access_token is None:
+        return None
+
+    token_attr = "_access_token"
+    if hasattr(request, token_attr):
+        token = getattr(request, token_attr, None)
+    else:
+        try:
+            token = get_token(access_token)
+        except:
+            token = None
+        setattr(request, token_attr, token)
+
+    if token is None:
         return None
     return parse_scope(token.scope)
 

--- a/media_auth/services.py
+++ b/media_auth/services.py
@@ -130,7 +130,7 @@ def get_access_token_from_request(request):
     return access_token
 
 def get_scope_from_request(request):
-    access_token = services.get_access_token_from_request(request)
+    access_token = get_access_token_from_request(request)
     try:
         token = get_token(access_token)
     except:

--- a/media_auth/services.py
+++ b/media_auth/services.py
@@ -132,7 +132,7 @@ def destroy_token(access_token):
 def get_access_token_from_request(request):
     authorization = request.META.get('HTTP_AUTHORIZATION', '')
     access_token = None
-    if authorization.lower().startswith("bearer "):
+    if authorization.lower().startswith("token "):
         access_token = authorization.split(" ", 2)[1]
     return access_token
 

--- a/media_auth/services.py
+++ b/media_auth/services.py
@@ -60,6 +60,7 @@ def obtain_token(data):
     # Return the token info
     token_response = {
         "access_token": token.key,
+        "scope": token.scope,
         "expires": TOKEN_EXPIRE.copy(),
     }
     logger.debug("Obtained token: %s" % token_response)

--- a/media_auth/services.py
+++ b/media_auth/services.py
@@ -58,13 +58,12 @@ def obtain_token(data):
         token = recent_tokens[0]
 
     # Return the token info
-    result = {
+    token_response = {
         "access_token": token.key,
-        "scope": token.scope,
         "expires": TOKEN_EXPIRE.copy(),
     }
-    logger.debug("Created token: %s" % result)
-    return result
+    logger.debug("Obtained token: %s" % token_response)
+    return token_response
 
 def get_token(access_token):
     return Token.objects.get(key=access_token)

--- a/media_auth/services.py
+++ b/media_auth/services.py
@@ -1,0 +1,124 @@
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.utils import timezone
+from media_service.models import UserProfile
+from .models import Application, Token
+
+import datetime
+import logging
+
+logger = logging.getLogger(__name__)
+
+TOKEN_EXPIRE = {"minutes": 1}
+
+class InvalidApplicationError(Exception):
+    pass
+
+class InvalidTokenError(Exception):
+    pass
+
+def create_token(data):
+    # Check that the required data are present
+    required_data = ('application_key', 'user_id', 'scope')
+    if not all([k in data for k in required_data]):
+        raise InvalidApplicationError("Missing required data. Must include: %s" % ", ".join(required_data))
+    
+    # Validate the application
+    application = None
+    if is_valid_application(data['application_key'], raise_exception=True):
+        application = Application.objects.get(key=data['application_key'])
+
+     # Get the user object or create a new one if needed
+    user = get_or_create_user(data['user_id'])
+    
+    # Use the scope as-is
+    scope = data['scope']
+
+    # Try to reuse the most recent token for the user if it's still valid, otherwise
+    # create a new token.
+    token_attrs = {
+        "scope": scope,
+        "user_profile": user.profile,
+        "application": application
+    }
+    recent_tokens = Token.objects.filter(**token_attrs).order_by('created')[0:1]
+    if len(recent_tokens) == 0 or is_token_expired(recent_tokens[0]):
+        token = Token(**token_attrs)
+        token.save()
+    else:
+        token = recent_tokens[0]
+
+    # Return the token info
+    result = {
+        "access_token": token.key,
+        "scope": token.scope,
+        "created": token.created.isoformat(),
+    }
+    logger.debug("Created token: %s" % result)
+    return result
+
+def get_token(token_key):
+    return Token.objects.get(key=token_key)
+
+def get_or_create_user(user_id):
+    user_profiles = UserProfile.objects.filter(sis_user_id=user_id)
+    user_profile = None
+    if len(user_profiles) == 0:
+        user_profile = UserProfile(sis_user_id=user_id)
+        user_profile.save()
+    else:
+        user_profile = user_profiles[0]
+    if not user_profile.user:
+        user = User.objects.create_user(username="UserProfile:%s" % user_profile.id, password=None)
+        user_profile.user = user
+        user_profile.save()
+    return user_profile.user
+
+def is_token_valid(token, raise_excetion=False):
+    return is_token_expired(token, raise_exception=raise_exception)
+
+def is_token_expired(token, raise_exception=False):
+    if isinstance(token, Token):
+        token_key = token.key
+    else:
+        token_key = token
+
+    try:
+        token = Token.objects.get(key=token_key)
+    except Token.DoesNotExist:
+        if raise_exception:
+            raise InvalidTokenError("No token exists with key %s" % token_key)
+        return True
+
+    created = token.created
+    now = timezone.now()
+    expiration = created + datetime.timedelta(**TOKEN_EXPIRE)
+    if now > expiration:
+        if raise_exception:
+            raise InvalidTokenError("Token has expired. Expired at: %s" % expiration)
+        return True
+
+    return False
+
+def is_valid_application(application_key, raise_exception=False):
+    try:
+        application = Application.objects.get(key=application_key)
+    except Application.DoesNotExist:
+        if raise_exception:
+            raise InvalidApplicationError("Invalid application_key: %s" % application_key)
+        return False
+    return True
+
+def destroy_token(token_key):
+    try:
+        Token.objects.get(key=token_key).delete()
+    except:
+        return True
+    return True
+
+def get_access_token_from_request(request):
+    authorization = request.META.get('AUTHORIZATION', '')
+    access_token = None
+    if authorization.lower().startswith("bearer "):
+        access_token = authorization.split(" ", 2)[1]
+    return access_token

--- a/media_auth/urls.py
+++ b/media_auth/urls.py
@@ -6,6 +6,6 @@ from . import views
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
     url(r'^create-token$', views.create_token, name='create-token'),
-    url(r'^check-token/(?P<token_key>.+)$', views.check_token, name='check-token'),
-    url(r'^destroy-token/(?P<token_key>.+)$', views.destroy_token, name='destroy-token'),
+    url(r'^check-token/(?P<access_token>.+)$', views.check_token, name='check-token'),
+    url(r'^destroy-token/(?P<access_token>.+)$', views.destroy_token, name='destroy-token'),
 ]

--- a/media_auth/urls.py
+++ b/media_auth/urls.py
@@ -5,7 +5,7 @@ from . import views
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
-    url(r'^create-token$', views.create_token, name='create-token'),
+    url(r'^obtain-token$', views.obtain_token, name='obtain-token'),
     url(r'^check-token/(?P<access_token>.+)$', views.check_token, name='check-token'),
     url(r'^destroy-token/(?P<access_token>.+)$', views.destroy_token, name='destroy-token'),
 ]

--- a/media_auth/urls.py
+++ b/media_auth/urls.py
@@ -1,0 +1,11 @@
+from django.conf.urls import url, include
+from django.views.generic.base import RedirectView
+from . import views 
+
+# Wire up our API using automatic URL routing.
+# Additionally, we include login URLs for the browsable API.
+urlpatterns = [
+    url(r'^create-token$', views.create_token, name='create-token'),
+    url(r'^check-token/(?P<token_key>.+)$', views.check_token, name='check-token'),
+    url(r'^destroy-token/(?P<token_key>.+)$', views.destroy_token, name='destroy-token'),
+]

--- a/media_auth/views.py
+++ b/media_auth/views.py
@@ -41,16 +41,16 @@ def create_token(request):
 
 @login_required
 @user_passes_test(lambda u: u and u.is_superuser)
-def check_token(request, token_key):
+def check_token(request, access_token):
     msg = "VALID"
     status = 200
-    if services.is_token_expired(token_key):
+    if services.is_token_expired(access_token):
         status = 404
         msg = "INVALID"
     return HttpResponse(msg, status=status)
 
 @login_required
 @user_passes_test(lambda u: u and u.is_superuser)
-def destroy_token(request, token_key):
-    services.destroy_token(token_key)
-    return HttpResponse("Deleted token key:%s" % (token_key))
+def destroy_token(request, access_token):
+    services.destroy_token(access_token)
+    return HttpResponse("Deleted token:%s" % (access_token))

--- a/media_auth/views.py
+++ b/media_auth/views.py
@@ -7,6 +7,7 @@ from django.contrib.auth.decorators import user_passes_test
 from django.views.decorators.http import require_http_methods
 from django.views.decorators.csrf import csrf_exempt
 from . import services
+from .exceptions import MediaAuthException
 
 import json
 import logging
@@ -15,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 @require_http_methods(["POST"])
 @csrf_exempt
-def create_token(request):
+def obtain_token(request):
     if not request.is_secure() and settings.DEBUG is not True:
         return HttpResponseBadRequest("Token request must be made over SSL!")
     if request.META['CONTENT_TYPE'] != 'application/json':
@@ -24,17 +25,18 @@ def create_token(request):
     data = None
     try:
         data = json.loads(request.body)
-        logger.debug("Request to create token given data: %s" % data)
+        logger.debug("Request to obtain token given data: %s" % data)
     except Exception as e:
-        errstr = "Error parsing request to create token: %s. Error: %s" % (request.body, str(e))
+        errstr = "Error parsing request to obtain token: %s. Error: %s" % (request.body, str(e))
         logger.error(errstr)
         return HttpResponseBadRequest(errstr)
 
     try:
-        token = services.create_token(data)
-    except services.InvalidApplicationError as e:
-        errstr = str(e)
-        return HttpResponseBadRequest(errstr)
+        token = services.obtain_token(data)
+    except MediaAuthException as e:
+        logger.debug(e.as_json())
+        return HttpResponseBadRequest(e.as_json())
+    
 
     token_json = json.dumps(token)
     return HttpResponse(content=token_json, content_type="application/json")

--- a/media_auth/views.py
+++ b/media_auth/views.py
@@ -1,0 +1,56 @@
+from django.conf import settings
+from django.shortcuts import render, get_object_or_404
+from django.http import HttpResponse, Http404, HttpResponseBadRequest
+from django.core.urlresolvers import reverse
+from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import user_passes_test
+from django.views.decorators.http import require_http_methods
+from django.views.decorators.csrf import csrf_exempt
+from . import services
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+@require_http_methods(["POST"])
+@csrf_exempt
+def create_token(request):
+    if not request.is_secure() and settings.DEBUG is not True:
+        return HttpResponseBadRequest("Token request must be made over SSL!")
+    if request.META['CONTENT_TYPE'] != 'application/json':
+        return HttpResponseBadRequest("CONTENT_TYPE must be 'application/json'")
+
+    data = None
+    try:
+        data = json.loads(request.body)
+        logger.debug("Request to create token given data: %s" % data)
+    except Exception as e:
+        errstr = "Error parsing request to create token: %s. Error: %s" % (request.body, str(e))
+        logger.error(errstr)
+        return HttpResponseBadRequest(errstr)
+
+    try:
+        token = services.create_token(data)
+    except services.InvalidApplicationError as e:
+        errstr = str(e)
+        return HttpResponseBadRequest(errstr)
+
+    token_json = json.dumps(token)
+    return HttpResponse(content=token_json, content_type="application/json")
+
+@login_required
+@user_passes_test(lambda u: u and u.is_superuser)
+def check_token(request, token_key):
+    msg = "VALID"
+    status = 200
+    if services.is_token_expired(token_key):
+        status = 404
+        msg = "INVALID"
+    return HttpResponse(msg, status=status)
+
+@login_required
+@user_passes_test(lambda u: u and u.is_superuser)
+def destroy_token(request, token_key):
+    services.destroy_token(token_key)
+    return HttpResponse("Deleted token key:%s" % (token_key))

--- a/media_management_api/settings/base.py
+++ b/media_management_api/settings/base.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'corsheaders',
     'media_service',
+    'media_auth',
 ]
 
 MIDDLEWARE_CLASSES = [
@@ -248,6 +249,10 @@ REST_FRAMEWORK = {
         'rest_framework.parsers.JSONParser',
         'rest_framework.parsers.FormParser',
         'rest_framework.parsers.MultiPartParser'
+    ),
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+         'rest_framework.authentication.SessionAuthentication',
+         'media_auth.authentication.CustomTokenAuthentication',
     ),
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }

--- a/media_management_api/settings/base.py
+++ b/media_management_api/settings/base.py
@@ -236,6 +236,11 @@ LOGGING = {
             'level': 'DEBUG',
             'propagate': True,
         },
+        'media_auth': {
+            'handlers': ['default', 'console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
     },
 }
 

--- a/media_management_api/urls.py
+++ b/media_management_api/urls.py
@@ -1,64 +1,12 @@
 from django.conf.urls import url, include
 from django.contrib import admin
-from django.views.decorators.csrf import csrf_exempt
-from rest_framework.urlpatterns import format_suffix_patterns
-from media_service import views
-
-course_list = views.CourseViewSet.as_view({
-    'get': 'list',
-    'post': 'create',
-})
-course_detail = views.CourseViewSet.as_view({
-    'get': 'retrieve',
-    'put': 'update',
-    'patch': 'partial_update',
-    'delete': 'destroy',
-})
-course_manifests = views.CourseViewSet.as_view({ 'get': 'manifests' })
-
-collection_list = views.CollectionViewSet.as_view({
-    'get': 'list',
-    'post': 'create',
-})
-collection_detail = views.CollectionViewSet.as_view({
-    'get': 'retrieve',
-    'put': 'update',
-    'patch': 'partial_update',
-    'delete': 'destroy',
-})
-collection_manifest = views.CollectionViewSet.as_view({ 'get': 'manifest' })
-
-image_list = views.CourseImageViewSet.as_view({
-    'get': 'list',
-    'post': 'create',
-})
-image_detail = views.CourseImageViewSet.as_view({
-    'get': 'retrieve',
-    'put': 'update',
-    'patch': 'partial_update',
-    'delete': 'destroy',
-})
-
+from django.views.generic.base import RedirectView
 
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
-    url(r'^$', views.APIRoot.as_view(), name="api-root"),
-    url(r'^courses$', course_list, name='course-list'),
-    url(r'^courses/(?P<pk>\d+)$', course_detail, name='course-detail'),
-    url(r'^courses/(?P<pk>\d+)/collections$', views.CourseCollectionsView.as_view(), name='course-collections'),
-    url(r'^courses/(?P<pk>\d+)/images$', views.CourseImagesListView.as_view(), name='course-images'),
-    url(r'^courses/(?P<pk>\d+)/manifests$', course_manifests, name='course-manifests'),
-    url(r'^collections$', collection_list, name='collection-list'),
-    url(r'^collections/(?P<pk>\d+)$', collection_detail, name='collection-detail'),
-    url(r'^collections/(?P<pk>\d+)/images$', views.CollectionImagesListView.as_view(), name='collectionimages-list'),
-    url(r'^collections/(?P<pk>\d+)/manifest$', collection_manifest, name='collection-manifest'),
-    url(r'^collection-images/(?P<pk>\d+)$', views.CollectionImagesDetailView.as_view(), name='collectionimages-detail'),
-    url(r'^images$', image_list, name='image-list'),
-    url(r'^images/(?P<pk>\d+)$', image_detail, name='image-detail'),
-    url(r'^images/(?P<pk>\d+)/upload$', views.CourseImageUploadView.as_view(), name='image-upload'),
+    url(r'^api/auth/', include('media_auth.urls', namespace='api-auth')),
+    url(r'^api/', include('media_service.urls')),
+    url(r'^$', RedirectView.as_view(url='/api/', permanent=False), name='index'),
 ]
-
-urlpatterns = format_suffix_patterns(urlpatterns)

--- a/media_service/admin.py
+++ b/media_service/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import MediaStore, Course, Collection, Resource, CollectionResource
+from .models import MediaStore, Course, Collection, Resource, CollectionResource, UserProfile
 
 class CollectionsInline(admin.StackedInline):
     extra = 0
@@ -33,3 +33,4 @@ admin.site.register(Course, CourseAdmin)
 admin.site.register(Collection, CollectionAdmin)
 admin.site.register(Resource)
 admin.site.register(CollectionResource)
+admin.site.register(UserProfile)

--- a/media_service/migrations/0002_auto_20160130_1747.py
+++ b/media_service/migrations/0002_auto_20160130_1747.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('media_service', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='collection',
+            options={'ordering': ['course', 'sort_order', 'title'], 'verbose_name': 'collection', 'verbose_name_plural': 'collections'},
+        ),
+        migrations.AlterModelOptions(
+            name='collectionresource',
+            options={'ordering': ['collection', 'sort_order', 'resource'], 'verbose_name': 'collection resource', 'verbose_name_plural': 'collection resources'},
+        ),
+        migrations.AlterModelOptions(
+            name='resource',
+            options={'ordering': ['course', 'sort_order', 'title'], 'verbose_name': 'resource', 'verbose_name_plural': 'resources'},
+        ),
+        migrations.RemoveField(
+            model_name='userprofile',
+            name='lti_user_id',
+        ),
+        migrations.AddField(
+            model_name='userprofile',
+            name='sis_user_id',
+            field=models.CharField(max_length=60, unique=True, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='collectionresource',
+            name='collection',
+            field=models.ForeignKey(related_name='resources', to='media_service.Collection'),
+        ),
+        migrations.AlterField(
+            model_name='collectionresource',
+            name='resource',
+            field=models.ForeignKey(related_name='collection_resources', to='media_service.Resource'),
+        ),
+        migrations.AlterField(
+            model_name='resource',
+            name='course',
+            field=models.ForeignKey(related_name='resources', to='media_service.Course'),
+        ),
+        migrations.AlterField(
+            model_name='resource',
+            name='owner',
+            field=models.ForeignKey(related_name='resources', blank=True, to='media_service.UserProfile', null=True),
+        ),
+        migrations.AlterField(
+            model_name='userprofile',
+            name='user',
+            field=models.OneToOneField(related_name='profile', null=True, on_delete=django.db.models.deletion.SET_NULL, blank=True, to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/media_service/models.py
+++ b/media_service/models.py
@@ -109,15 +109,15 @@ class MediaStore(BaseModel):
         return url_format_str.format(base_url=IIIF_IMAGE_SERVER_URL, **iiif_spec)
 
 class UserProfile(BaseModel):
-    user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
-    lti_user_id = models.CharField(max_length=1024, unique=True, blank=True)
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, related_name="profile", null=True, blank=True)
+    sis_user_id = models.CharField(max_length=60, unique=True, blank=True, null=True)
 
     class Meta:
         verbose_name = 'user_profile'
         verbose_name_plural = 'user_profiles'
 
     def __unicode__(self):
-        return "{0}:{1}".format(self.id, self.lti_user_id)
+        return "UserProfile:%s" % self.id
 
 class Course(BaseModel):
     title = models.CharField(max_length=255)
@@ -139,7 +139,7 @@ class Course(BaseModel):
 
 class Resource(BaseModel, SortOrderModelMixin):
     course = models.ForeignKey(Course, on_delete=models.CASCADE, related_name='resources')
-    owner = models.ForeignKey(UserProfile, null=True)
+    owner = models.ForeignKey(UserProfile, on_delete=models.CASCADE, related_name='resources', null=True, blank=True)
     media_store = models.ForeignKey(MediaStore, null=True, on_delete=models.SET_NULL)
     is_upload = models.BooleanField(default=True, null=False)
     upload_file_name = models.CharField(max_length=4096, null=True)
@@ -152,7 +152,6 @@ class Resource(BaseModel, SortOrderModelMixin):
     thumb_height = models.PositiveIntegerField(null=True)
     title = models.CharField(max_length=255)
     description = models.TextField(blank=True)
-    
     sort_order = models.IntegerField(default=0)
 
     class Meta:

--- a/media_service/tests/test_views.py
+++ b/media_service/tests/test_views.py
@@ -9,9 +9,10 @@ class TestCourseEndpoint(APITestCase):
     fixtures = ['test.json']
 
     def setUp(self):
-        credentials = {"username": "testuser", "password": "testuser"}
-        self.testuser = User.objects.create_user(credentials['username'], 'testuser@localhost', credentials['password'])
-        self.testuser_credentials = credentials
+        self.credentials = {"username": "testuser", "password": "testuser"}
+        self.testuser = User.objects.create(username=self.credentials['username'])
+        self.testuser.set_password(self.credentials['password'])
+        self.client.force_authenticate(self.testuser)
 
     def get_example_item(self, detail=False):
         example_item = {
@@ -73,6 +74,7 @@ class TestCourseEndpoint(APITestCase):
     def test_course_list(self):
         courses = Course.objects.all()
         url = reverse('course-list')
+        self.client.login(username=self.credentials['username'], password=self.credentials['password'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), len(courses))
@@ -187,9 +189,10 @@ class TestCollectionEndpoint(APITestCase):
     fixtures = ['test.json']
 
     def setUp(self):
-        credentials = {"username": "testuser", "password": "testuser"}
-        self.testuser = User.objects.create_user(credentials['username'], 'testuser@localhost', credentials['password'])
-        self.testuser_credentials = credentials
+        self.credentials = {"username": "testuser", "password": "testuser"}
+        self.testuser = User.objects.create(username=self.credentials['username'])
+        self.testuser.set_password(self.credentials['password'])
+        self.client.force_authenticate(self.testuser)
 
     def test_collection_list(self):
         collections = Collection.objects.all()

--- a/media_service/tests/test_views.py
+++ b/media_service/tests/test_views.py
@@ -1,11 +1,17 @@
 import unittest
 from django.core.urlresolvers import reverse
+from django.contrib.auth.models import User
 from rest_framework import status
 from rest_framework.test import APITestCase
-from media_service.models import MediaStore, Course, Collection, Resource, CollectionResource
+from media_service.models import MediaStore, Course, Collection, Resource, CollectionResource, UserProfile
 
 class TestCourseEndpoint(APITestCase):
     fixtures = ['test.json']
+
+    def setUp(self):
+        credentials = {"username": "testuser", "password": "testuser"}
+        self.testuser = User.objects.create_user(credentials['username'], 'testuser@localhost', credentials['password'])
+        self.testuser_credentials = credentials
 
     def get_example_item(self, detail=False):
         example_item = {
@@ -179,6 +185,11 @@ class TestCourseEndpoint(APITestCase):
     
 class TestCollectionEndpoint(APITestCase):
     fixtures = ['test.json']
+
+    def setUp(self):
+        credentials = {"username": "testuser", "password": "testuser"}
+        self.testuser = User.objects.create_user(credentials['username'], 'testuser@localhost', credentials['password'])
+        self.testuser_credentials = credentials
 
     def test_collection_list(self):
         collections = Collection.objects.all()

--- a/media_service/urls.py
+++ b/media_service/urls.py
@@ -1,0 +1,58 @@
+from django.conf.urls import url, include
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework.urlpatterns import format_suffix_patterns
+import views
+
+course_list = views.CourseViewSet.as_view({
+    'get': 'list',
+    'post': 'create',
+})
+course_detail = views.CourseViewSet.as_view({
+    'get': 'retrieve',
+    'put': 'update',
+    'patch': 'partial_update',
+    'delete': 'destroy',
+})
+course_manifests = views.CourseViewSet.as_view({ 'get': 'manifests' })
+
+collection_list = views.CollectionViewSet.as_view({
+    'get': 'list',
+    'post': 'create',
+})
+collection_detail = views.CollectionViewSet.as_view({
+    'get': 'retrieve',
+    'put': 'update',
+    'patch': 'partial_update',
+    'delete': 'destroy',
+})
+collection_manifest = views.CollectionViewSet.as_view({ 'get': 'manifest' })
+
+image_list = views.CourseImageViewSet.as_view({
+    'get': 'list',
+    'post': 'create',
+})
+image_detail = views.CourseImageViewSet.as_view({
+    'get': 'retrieve',
+    'put': 'update',
+    'patch': 'partial_update',
+    'delete': 'destroy',
+})
+
+urlpatterns = [
+    url(r'^$', views.APIRoot.as_view(), name="root"),
+    url(r'^courses$', course_list, name='course-list'),
+    url(r'^courses/(?P<pk>\d+)$', course_detail, name='course-detail'),
+    url(r'^courses/(?P<pk>\d+)/collections$', views.CourseCollectionsView.as_view(), name='course-collections'),
+    url(r'^courses/(?P<pk>\d+)/images$', views.CourseImagesListView.as_view(), name='course-images'),
+    url(r'^courses/(?P<pk>\d+)/manifests$', course_manifests, name='course-manifests'),
+    url(r'^collections$', collection_list, name='collection-list'),
+    url(r'^collections/(?P<pk>\d+)$', collection_detail, name='collection-detail'),
+    url(r'^collections/(?P<pk>\d+)/images$', views.CollectionImagesListView.as_view(), name='collectionimages-list'),
+    url(r'^collections/(?P<pk>\d+)/manifest$', collection_manifest, name='collection-manifest'),
+    url(r'^collection-images/(?P<pk>\d+)$', views.CollectionImagesDetailView.as_view(), name='collectionimages-detail'),
+    url(r'^images$', image_list, name='image-list'),
+    url(r'^images/(?P<pk>\d+)$', image_detail, name='image-detail'),
+    url(r'^images/(?P<pk>\d+)/upload$', views.CourseImageUploadView.as_view(), name='image-upload'),
+]
+
+urlpatterns = format_suffix_patterns(urlpatterns)

--- a/media_service/views.py
+++ b/media_service/views.py
@@ -7,7 +7,9 @@ from rest_framework.decorators import detail_route, list_route, api_view
 from rest_framework.reverse import reverse
 from rest_framework.parsers import JSONParser, FormParser, MultiPartParser, FileUploadParser
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.exceptions import PermissionDenied
 
+from media_auth.services import get_scope_from_request
 from media_service.models import Course, Collection, Resource, MediaStore, CollectionResource
 from media_service.serializers import UserSerializer, CourseSerializer, ResourceSerializer, \
     CollectionSerializer, CollectionResourceSerializer

--- a/media_service/views.py
+++ b/media_service/views.py
@@ -9,11 +9,13 @@ from rest_framework.parsers import JSONParser, FormParser, MultiPartParser, File
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.exceptions import PermissionDenied
 
-from media_auth.services import get_scope_from_request
 from media_service.models import Course, Collection, Resource, MediaStore, CollectionResource
-from media_service.serializers import UserSerializer, CourseSerializer, ResourceSerializer, \
-    CollectionSerializer, CollectionResourceSerializer
 from media_service.iiif import CollectionManifestController
+from media_service.serializers import UserSerializer, CourseSerializer, ResourceSerializer, CollectionSerializer, CollectionResourceSerializer
+
+from media_auth.filters import CourseEndpointFilter, CollectionEndpointFilter, ResourceEndpointFilter
+from media_auth.permissions import CourseEndpointPermission, CollectionEndpointPermission, ResourceEndpointPermission, CollectionResourceEndpointPermission
+
 
 class APIRoot(APIView):
     def get(self, request, format=None):
@@ -52,24 +54,25 @@ To search for a course associated with an LTI context:
 Since one and only one instance of a course can exist with those two attributes, the response should
 be an empty list or a list with one object.
     '''
-    queryset = Course.objects.prefetch_related('resources', 'collections', 'collections__resources')
+    queryset = Course.objects.prefetch_related('resources', 'collections', 'collections__resources', 'resources__media_store')
     serializer_class = CourseSerializer
-    permission_classes = (IsAuthenticated,)
-    
-    def _get_lti_search_filters(self, request):
-        lti_search = {}
-        for k in ['lti_context_id', 'lti_tool_consumer_instance_guid']:
-            if k in request.GET:
-                lti_search[k] = request.GET[k]
-        return lti_search
+    permission_classes = (IsAuthenticated, CourseEndpointPermission)
+
+    def get_queryset(self):
+        queryset = super(CourseViewSet, self).get_queryset()
+        queryset = CourseEndpointFilter(self).filter_queryset(queryset)
+        return queryset
     
     def list(self, request, format=None):
-        lti_search = self._get_lti_search_filters(request)
-        if len(lti_search.keys()) > 0:
-            courses = self.get_queryset().filter(**lti_search)
-        else:
-            courses = self.get_queryset()
-        serializer = CourseSerializer(courses, many=True, context={'request': request})
+        queryset = self.get_queryset()
+
+        # Filter queryset by LTI context params
+        lti_params = ('lti_context_id', 'lti_tool_consumer_instance_guid')
+        lti_filters = dict([(k, self.request.GET[k]) for k in lti_params if k in self.request.GET])
+        if len(lti_filters.keys()) > 0:
+            queryset = queryset.filter(**lti_filters)
+    
+        serializer = CourseSerializer(queryset, many=True, context={'request': request})
         return Response(serializer.data)
 
     def retrieve(self, request, pk=None, format=None):
@@ -102,9 +105,14 @@ Collection Endpoints
 - `/collections/{pk}` Collection detail
 - `/collections/{pk}/images`  Lists a collection's images
     '''
-    queryset = Collection.objects.select_related('course').prefetch_related('resources__resource')
+    queryset = Collection.objects.select_related('course').prefetch_related('resources__resource__media_store')
     serializer_class = CollectionSerializer
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, CollectionEndpointPermission)
+
+    def get_queryset(self):
+        queryset = super(CollectionViewSet, self).get_queryset()
+        queryset = CollectionEndpointFilter(self).filter_queryset(queryset)
+        return queryset
     
     def list(self, request, format=None):
         collections = self.get_queryset()
@@ -127,7 +135,7 @@ Collection Endpoints
 class CourseCollectionsView(GenericAPIView):
     queryset = Collection.objects.select_related('course').prefetch_related('resources__resource__media_store')
     serializer_class = CollectionSerializer
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, CollectionEndpointPermission)
 
     def get(self, request, pk=None, format=None):
         course_pk = pk
@@ -151,7 +159,7 @@ class CourseImagesListView(GenericAPIView):
     serializer_class = ResourceSerializer
     queryset = Resource.objects.select_related('course', 'media_store')
     parser_classes = (JSONParser, MultiPartParser, FormParser)
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, ResourceEndpointPermission)
 
     def get(self, request, pk=None, format=None):
         course_pk = pk
@@ -171,11 +179,12 @@ class CourseImagesListView(GenericAPIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
     
 class CollectionImagesListView(APIView):
+    queryset = CollectionResource.objects.select_related('collection', 'resource')
     serializer_class = CollectionResourceSerializer
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, pk=None, format=None):
-        collection_resources = CollectionResource.get_collection_images(pk)
+        collection_resources = self.get_queryset().filter(collection__pk=pk).order_by('sort_order')
         serializer = CollectionResourceSerializer(collection_resources, many=True, context={'request': request})
         return Response(serializer.data)
 
@@ -193,25 +202,27 @@ class CollectionImagesListView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 class CollectionImagesDetailView(APIView):
+    queryset = CollectionResource.objects.all()
     serializer_class = CollectionResourceSerializer
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, pk=None, format=None):
-         collection_resource = get_object_or_404(CollectionResource, pk=pk)
+         collection_resource = self.get_object()
          serializer = CollectionResourceSerializer(collection_resource, context={'request': request})
          return Response(serializer.data)
     
     def delete(self, request, pk=None, format=None):
-        collection_resource = get_object_or_404(CollectionResource, pk=pk)
+        collection_resource = self.get_object()
         collection_resource.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 class CourseImageUploadView(APIView):
+    queryset = Resource.objects.select_related('course', 'media_store')
     parser_classes = (MultiPartParser, FormParser)
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, ResourceEndpointPermission)
 
     def post(self, request, pk=None, format=None):
-        instance = get_object_or_404(Resource, pk=pk)
+        instance = self.get_object()
         data = request.data.copy()
         data['course_id'] = instance.course.pk
         serializer = ResourceSerializer(data=data, instance=instance, context={'request': request})
@@ -221,7 +232,11 @@ class CourseImageUploadView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 class CourseImageViewSet(viewsets.ModelViewSet):
-    queryset = Resource.objects.all()
+    queryset = Resource.objects.select_related('course', 'media_store')
     serializer_class = ResourceSerializer
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, ResourceEndpointPermission)
 
+    def get_queryset(self):
+        queryset = super(CourseImageViewSet, self).get_queryset()
+        queryset = ResourceEndpointFilter(self).filter_queryset(queryset)
+        return queryset

--- a/media_service/views.py
+++ b/media_service/views.py
@@ -6,6 +6,8 @@ from rest_framework.response import Response
 from rest_framework.decorators import detail_route, list_route, api_view
 from rest_framework.reverse import reverse
 from rest_framework.parsers import JSONParser, FormParser, MultiPartParser, FileUploadParser
+from rest_framework.permissions import IsAuthenticated
+
 from media_service.models import Course, Collection, Resource, MediaStore, CollectionResource
 from media_service.serializers import UserSerializer, CourseSerializer, ResourceSerializer, \
     CollectionSerializer, CollectionResourceSerializer
@@ -50,6 +52,7 @@ be an empty list or a list with one object.
     '''
     queryset = Course.objects.prefetch_related('resources', 'collections', 'collections__resources')
     serializer_class = CourseSerializer
+    permission_classes = (IsAuthenticated,)
     
     def _get_lti_search_filters(self, request):
         lti_search = {}
@@ -99,6 +102,7 @@ Collection Endpoints
     '''
     queryset = Collection.objects.select_related('course').prefetch_related('resources__resource')
     serializer_class = CollectionSerializer
+    permission_classes = (IsAuthenticated,)
     
     def list(self, request, format=None):
         collections = self.get_queryset()
@@ -121,6 +125,8 @@ Collection Endpoints
 class CourseCollectionsView(GenericAPIView):
     queryset = Collection.objects.select_related('course').prefetch_related('resources__resource__media_store')
     serializer_class = CollectionSerializer
+    permission_classes = (IsAuthenticated,)
+
     def get(self, request, pk=None, format=None):
         course_pk = pk
         collections = self.get_queryset().filter(course__pk=course_pk).order_by('sort_order')
@@ -143,6 +149,8 @@ class CourseImagesListView(GenericAPIView):
     serializer_class = ResourceSerializer
     queryset = Resource.objects.select_related('course', 'media_store')
     parser_classes = (JSONParser, MultiPartParser, FormParser)
+    permission_classes = (IsAuthenticated,)
+
     def get(self, request, pk=None, format=None):
         course_pk = pk
         images = self.get_queryset().filter(course__pk=course_pk).order_by('sort_order')
@@ -162,6 +170,8 @@ class CourseImagesListView(GenericAPIView):
     
 class CollectionImagesListView(APIView):
     serializer_class = CollectionResourceSerializer
+    permission_classes = (IsAuthenticated,)
+
     def get(self, request, pk=None, format=None):
         collection_resources = CollectionResource.get_collection_images(pk)
         serializer = CollectionResourceSerializer(collection_resources, many=True, context={'request': request})
@@ -182,6 +192,8 @@ class CollectionImagesListView(APIView):
 
 class CollectionImagesDetailView(APIView):
     serializer_class = CollectionResourceSerializer
+    permission_classes = (IsAuthenticated,)
+
     def get(self, request, pk=None, format=None):
          collection_resource = get_object_or_404(CollectionResource, pk=pk)
          serializer = CollectionResourceSerializer(collection_resource, context={'request': request})
@@ -194,6 +206,8 @@ class CollectionImagesDetailView(APIView):
 
 class CourseImageUploadView(APIView):
     parser_classes = (MultiPartParser, FormParser)
+    permission_classes = (IsAuthenticated,)
+
     def post(self, request, pk=None, format=None):
         instance = get_object_or_404(Resource, pk=pk)
         data = request.data.copy()
@@ -207,3 +221,5 @@ class CourseImageUploadView(APIView):
 class CourseImageViewSet(viewsets.ModelViewSet):
     queryset = Resource.objects.all()
     serializer_class = ResourceSerializer
+    permission_classes = (IsAuthenticated,)
+


### PR DESCRIPTION
This PR adds authentication to the API via a token authentication scheme. Clients must present a valid  token to the API in order to read or write to protected resources. The assumption is that the API has a "trust" relationship with a defined set of applications, but does not trust the end-users of those applications. It's assumed that end-users will have access to the token, so the token needs to be opaque and relatively short-lived. Applications will need to obtain tokens frequently (i.e. every LTI launch).

It wasn't clear to me how we could easily apply oauth2 to this use case, although I'm sure there's a way to do it. The most common oauth2 workflows seem to assume that you have a *user* that wants to grant a third party application access to *their* protected resources. However, in our case, we have an *application* that wants to grant untrusted users access to *its own* protected resources. The end users do not have accounts on the API (i.e. can't login),but some users may be *resource owners* if they've uploaded images. This authentication flow satisfies our requirements, but I've tried to design this module in such a way that it could be replaced if there's a simpler way to do it with oauth2.

Here's how the authentication scheme works:

**Step 1: Register application**
The application (i.e. media mangler) must first be registered with the API and have a *client_id* and *client_secret* assigned to it. This is a manual step that you'll need to do on the admin interface (just create a new *media_auth.Application* model instance with a *client_id* and *client_secret*.

**Step 2: Obtain a token**
Request (must be over SSL):
```
POST /api/auth/obtain-token
{
    "client_id": "testclient",
    "client_secret": "secret",
    "scope": "read:course:1",
    "user_id": "testuser"
}
```
Response:
```
{
    "access_token": "aeo0c4zvasdf", 
    "expires": {"minutes": 15}
}
```

The *scope* parameter is intended to give the token bearer *read* or *write* access to one, many, or all courses. Examples:
* `write:course:1` Write access to course object 1 (implies read too)
* `read:course:1,2,3` Read access to course objects 1, 2, and 3.
* `write:course:*` Write access to all courses (needed to create a course)

**Step 3: Make requests to the API**
Application clients must use SSL to make requests and add the following header to authenticate:

```
Authorization: Token <access_token>
```

Note: if you're logged in through the django *admin* console, you should have full access to the API on the web UI. The *scope* is only applied if it's present in the request. The only other check is that the user is authenticated.

@jazahn FYI
@MichaelDHilborn-Harvard Review?