### PR TITLE
feature/metadata

### DIFF
--- a/media_service/migrations/0003_resource_metadata.py
+++ b/media_service/migrations/0003_resource_metadata.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('media_service', '0002_auto_20160130_1747'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='resource',
+            name='metadata',
+            field=models.TextField(default=b'[]', blank=True),
+        ),
+    ]

--- a/media_service/models.py
+++ b/media_service/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.db.models import Max
 from django.conf import settings
 import urllib
+import json
 
 # Required settings
 IIIF_IMAGE_SERVER_URL = settings.IIIF_IMAGE_SERVER_URL
@@ -143,15 +144,16 @@ class Resource(BaseModel, SortOrderModelMixin):
     media_store = models.ForeignKey(MediaStore, null=True, on_delete=models.SET_NULL)
     is_upload = models.BooleanField(default=True, null=False)
     upload_file_name = models.CharField(max_length=4096, null=True)
-    img_type = models.CharField(max_length=128, null=True)
-    img_url = models.CharField(max_length=4096, null=True)
-    img_width = models.PositiveIntegerField(null=True)
-    img_height = models.PositiveIntegerField(null=True)
-    thumb_url = models.CharField(max_length=4096, null=True)
-    thumb_width = models.PositiveIntegerField(null=True)
-    thumb_height = models.PositiveIntegerField(null=True)
+    img_type = models.CharField(max_length=128, null=True, blank=True)
+    img_url = models.CharField(max_length=4096, null=True, blank=True)
+    img_width = models.PositiveIntegerField(null=True, blank=True)
+    img_height = models.PositiveIntegerField(null=True, blank=True)
+    thumb_url = models.CharField(max_length=4096, null=True, blank=True)
+    thumb_width = models.PositiveIntegerField(null=True, blank=True)
+    thumb_height = models.PositiveIntegerField(null=True, blank=True)
     title = models.CharField(max_length=255)
     description = models.TextField(blank=True)
+    metadata = models.TextField(blank=True, default=json.dumps([]))
     sort_order = models.IntegerField(default=0)
 
     class Meta:
@@ -206,6 +208,11 @@ class Resource(BaseModel, SortOrderModelMixin):
         }
         return data
     
+    def load_metadata(self):
+        try:
+            return json.loads(self.metadata)
+        except:
+            return []
 
     def __unicode__(self):
         return "{0}:{1}".format(self.id, self.title)

--- a/media_service/tests/test_iiif.py
+++ b/media_service/tests/test_iiif.py
@@ -33,9 +33,9 @@ class IIIFManifestTest(unittest.TestCase):
 
     def get_images_list(self):
         images = [
-            {'id': 1, 'is_link': False, 'url': 'http://localhost:8000/loris/foo.jpg', 'label': 'foo.jpg'},
-            {'id': 2, 'is_link': False, 'url': 'http://localhost:8000/loris/bar.jpg', 'label': 'bar.jpg'},
-            {'id': 3, 'is_link': True, 'url': 'http://my.link/image.jpg', 'label': 'image.jpg'},
+            {'id': 1, 'is_link': False, 'url': 'http://localhost:8000/loris/foo.jpg', 'label': 'foo.jpg', 'description': '', 'metadata': []},
+            {'id': 2, 'is_link': False, 'url': 'http://localhost:8000/loris/bar.jpg', 'label': 'bar.jpg', 'description': '', 'metadata': []},
+            {'id': 3, 'is_link': True, 'url': 'http://my.link/image.jpg', 'label': 'image.jpg', 'description': '', 'metadata': []},
         ]
         return images
 

--- a/media_service/tests/test_views.py
+++ b/media_service/tests/test_views.py
@@ -36,6 +36,7 @@ class TestCourseEndpoint(APITestCase):
                         "course_id": 1,
                         "title": "Example Image",
                         "description": "",
+                        "metadata": "[]",
                         "sort_order": 0,
                         "upload_file_name": None,
                         "created": "2015-12-15T15:42:33.443434Z",


### PR DESCRIPTION
This PR adds the ability to set metadata on images in the course library (i.e. **Resource** model). The metadata is stored as a JSON blob in the Django model because I'm assuming the following:

1. We need to support user-defined metadata fields that can be displayed along with images (easy with JSON blobs).
2. We don't need the metadata to be optimized for search/discoverability (hard/inefficient with JSON blobs). 

Metadata is expected to be structured as a list of pairs like this:

```json
[
    {"label": "one", "value": "two"},
    {"label": "foo", "value": "bar"},
    {"label": "x", "value": "y"},
]
```

Each `label` and `value` is expected to be a string. If it's not a string, then a validation error will be raised. An alternative to hard failing on non-string types would be to coerce the value into a string no matter what. But for now, it just hard fails if it doesn't get a string value.

Example PUT request:
```
PUT /api/images/142

{
  "id": 142,
  "course_id": 1,
  "title": "Super Awesome Image",
  "description": "A description here...",
  "metadata": [
    {"label": "one", "value": "two"},
    {"label": "foo", "value": "bar"},
    {"label": "x", "value": "y"}
  ]
}
```


@jazahn @MichaelDHilborn-Harvard review?