### PR TITLE
feature/zip

### DIFF
--- a/media_service/mediastore.py
+++ b/media_service/mediastore.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class MediaStoreUploadException(Exception):
     pass
 
-def process_zip(filelist):
+def processFileUploads(filelist):
     '''
     processes a file upload list, unzipping all zips
     returns a new list with unzipped files

--- a/media_service/mediastore.py
+++ b/media_service/mediastore.py
@@ -34,7 +34,7 @@ def processFileUploads(filelist):
     '''
     newlist = []
     for file in filelist:
-        if "zip" in file.content_type:
+        if zipfile.is_zipfile(file):
             # unzip and append to the list
             zip = zipfile.ZipFile(file, "r")
             for f in zip.namelist():
@@ -78,7 +78,6 @@ class MediaStoreUpload:
             media_store_instance = media_store_upload.save()
     '''
     VALID_IMAGE_EXTENSIONS = ('jpg', 'gif', 'png')
-    VALID_ZIP_EXTENSIONS = ('zip',)
 
     def __init__(self, uploaded_file):
 

--- a/media_service/mediastore.py
+++ b/media_service/mediastore.py
@@ -1,3 +1,4 @@
+import io
 import os
 import hashlib
 import tempfile
@@ -25,6 +26,30 @@ logger = logging.getLogger(__name__)
 
 class MediaStoreUploadException(Exception):
     pass
+
+def process_zip(filelist):
+    '''
+    processes a file upload list, unzipping all zips
+    returns a new list with unzipped files
+    '''
+    newlist = []
+    for file in filelist:
+        if "zip" in file.content_type:
+            # unzip and append to the list
+            zip = zipfile.ZipFile(file, "r")
+            for f in zip.namelist():
+                logger.debug("ZipFile content: %s" % f)
+                zf = zip.open(f).read()
+                newfile = File(io.BytesIO(zf))
+                newfile.name = f
+
+                # avoiding temp files added to archive
+                if "__MACOSX" not in newfile.name:
+                    newlist.append(newfile)
+        else:
+            newlist.append(file)
+
+    return newlist
 
 class MediaStoreUpload:
     '''

--- a/media_service/tests/test_mediastore.py
+++ b/media_service/tests/test_mediastore.py
@@ -1,6 +1,5 @@
 import unittest
 import base64
-import re
 from mock import MagicMock
 from django.core.files.uploadedfile import SimpleUploadedFile
 from media_service.mediastore import MediaStoreUpload, MediaStoreUploadException
@@ -8,6 +7,12 @@ from media_service.models import MediaStore
 
 class TestMediaStoreUpload(unittest.TestCase):
     test_files = {
+        'test.zip': {
+            'filename': 'test.zip',
+            'extension': 'zip',
+            'content-type': 'application/zip',
+            'content':
+        },
         'test.png': {
             'filename': 'test.png',
             'extension': 'png',
@@ -41,7 +46,7 @@ class TestMediaStoreUpload(unittest.TestCase):
 
     def tearDown(self):
         pass
-    
+
     def createUploadedFile(self, test_file):
         return SimpleUploadedFile.from_dict({
             'filename': test_file['filename'],
@@ -51,19 +56,19 @@ class TestMediaStoreUpload(unittest.TestCase):
 
     def createMediaStoreUpload(self, test_file):
         uploaded_file = self.createUploadedFile(test_file)
-        return MediaStoreUpload(uploaded_file)        
+        return MediaStoreUpload(uploaded_file)
 
     def testCreateMediaStoreUpload(self):
         instance = self.createMediaStoreUpload(self.test_files['test.png'])
         self.assertTrue(isinstance(instance, MediaStoreUpload))
-    
+
     def testFileHash(self):
         instance = self.createMediaStoreUpload(self.test_files['test.png'])
         file_md5hash = instance.getFileHash()
         m = re.search('^[0-9a-f]{32}', file_md5hash)
         self.assertTrue(m)
         self.assertEqual(file_md5hash, m.group(0))
-    
+
     def testImageDimensions(self):
         test_file = self.test_files['test.png']
         instance = self.createMediaStoreUpload(test_file)
@@ -71,7 +76,7 @@ class TestMediaStoreUpload(unittest.TestCase):
         actual = {'w':w, 'h':h}
         expected = test_file['dimensions']
         self.assertEqual(actual, expected)
-    
+
     def testFileExtension(self):
         test_file = self.test_files['test.png']
         instance = self.createMediaStoreUpload(test_file)
@@ -81,18 +86,18 @@ class TestMediaStoreUpload(unittest.TestCase):
         test_file = self.test_files['test.png']
         instance = self.createMediaStoreUpload(test_file)
         self.assertEqual(instance.getFileType(), test_file['content-type'])
-    
+
     def testFileSize(self):
         test_file = self.test_files['test.png']
         instance = self.createMediaStoreUpload(test_file)
         self.assertEqual(instance.getFileSize(), len(test_file['content']))
-    
+
     def testCreateFileName(self):
         test_file = self.test_files['test.png']
         instance = self.createMediaStoreUpload(test_file)
         expected_filename = '%s.%s' % (instance.getFileHash(), instance.getFileExtension())
         self.assertEqual(instance.createFileName(), expected_filename)
-    
+
     def testCreateMediaStoreInstance(self):
         test_file = self.test_files['test.png']
         media_store_upload = self.createMediaStoreUpload(test_file)
@@ -102,49 +107,49 @@ class TestMediaStoreUpload(unittest.TestCase):
         self.assertEqual(media_store.file_type, media_store_upload.getFileType())
         self.assertEqual(media_store.file_md5hash, media_store_upload.getFileHash())
         self.assertEqual(media_store.file_extension, media_store_upload.getFileExtension())
-        
+
         w, h = media_store_upload.getImageDimensions()
         self.assertEqual(media_store.img_width, w)
         self.assertEqual(media_store.img_height, h)
-    
+
     def testInstanceExists(self):
         test_file = self.test_files['test.png']
         media_store_upload = self.createMediaStoreUpload(test_file)
-        
+
         self.assertFalse(media_store_upload.instanceExists())
         media_store = media_store_upload.createInstance()
         media_store.save()
         self.assertTrue(media_store_upload.instanceExists())
         media_store.delete()
         self.assertFalse(media_store_upload.instanceExists())
-    
+
     def testGetInstance(self):
         test_file = self.test_files['test.png']
         media_store_upload = self.createMediaStoreUpload(test_file)
         with self.assertRaises(Exception) as context:
             media_store_upload.getInstance()
         self.assertTrue(isinstance(context.exception, MediaStore.DoesNotExist))
-        
+
         media_store = media_store_upload.createInstance()
         media_store.save()
-        
+
         found = media_store_upload.getInstance()
         self.assertEqual(found.pk, media_store.pk)
         found.delete()
-    
+
     def testS3FileKey(self):
         test_file = self.test_files['test.png']
         media_store_upload = self.createMediaStoreUpload(test_file)
         media_store_upload.saveToBucket = MagicMock(return_value=True)
-        
+
         with self.assertRaises(Exception) as context:
             media_store_upload.getS3FileKey()
         self.assertTrue(isinstance(context.exception, MediaStoreUploadException))
-        
+
         media_store = media_store_upload.save()
         self.assertTrue(media_store_upload.getS3FileKey())
         media_store.delete()
-    
+
     def testSaveDoesNotExist(self):
         test_file = self.test_files['test.png']
         media_store_upload = self.createMediaStoreUpload(test_file)
@@ -154,7 +159,7 @@ class TestMediaStoreUpload(unittest.TestCase):
         self.assertTrue(media_store)
         media_store_upload.saveToBucket.assert_called_once_with()
         media_store.delete()
-    
+
     def testSaveDoesExist(self):
         test_file = self.test_files['test.png']
         m1 = self.createMediaStoreUpload(test_file)
@@ -162,29 +167,29 @@ class TestMediaStoreUpload(unittest.TestCase):
         self.assertFalse(m1.instanceExists())
         r1 = m1.save()
         m1.saveToBucket.assert_called_once_with()
-        
+
         m2 = self.createMediaStoreUpload(test_file)
         m2.saveToBucket = MagicMock(return_value=True)
         self.assertTrue(m2.instanceExists())
         r2 = m2.save()
         m2.saveToBucket.assert_not_called()
-        
+
         self.assertEqual(r1.pk, r2.pk)
         r2.delete()
-    
+
     def testInvalidExtension(self):
         test_file = self.test_files['test.badextension']
         media_store_upload = self.createMediaStoreUpload(test_file)
         self.assertFalse(media_store_upload.validateImageExtension())
         self.assertFalse(media_store_upload.isValid())
-    
+
     def testInvalidImage(self):
         test_file = self.test_files['empty.jpg']
         media_store_upload = self.createMediaStoreUpload(test_file)
         self.assertTrue(media_store_upload.validateImageExtension())
         self.assertFalse(media_store_upload.validateImageOpens())
         self.assertFalse(media_store_upload.isValid())
-    
+
     def testImageJpegExtensionNormalized(self):
         test_file = self.test_files['empty.jpeg']
         media_store_upload = self.createMediaStoreUpload(test_file)

--- a/media_service/tests/test_mediastore.py
+++ b/media_service/tests/test_mediastore.py
@@ -1,5 +1,6 @@
 import unittest
 import base64
+import re
 from mock import MagicMock
 from django.core.files.uploadedfile import SimpleUploadedFile
 from media_service.mediastore import MediaStoreUpload, MediaStoreUploadException
@@ -7,12 +8,6 @@ from media_service.models import MediaStore
 
 class TestMediaStoreUpload(unittest.TestCase):
     test_files = {
-        'test.zip': {
-            'filename': 'test.zip',
-            'extension': 'zip',
-            'content-type': 'application/zip',
-            'content':
-        },
         'test.png': {
             'filename': 'test.png',
             'extension': 'png',

--- a/media_service/tests/test_mediastore.py
+++ b/media_service/tests/test_mediastore.py
@@ -202,13 +202,15 @@ class TestZipUpload(unittest.TestCase):
     test_files = TEST_FILES
 
     @patch('zipfile.ZipFile')
-    def testProcessFileUploads(self, mock_zip):
+    @patch('zipfile.is_zipfile')
+    def testProcessFileUploads(self, mock_is_zipfile, mock_zip):
         testZip = MockZipFile()
         testZip.write(self.test_files['test.png'])
         testZip.write(self.test_files['empty.jpg'])
 
         files = [testZip]
         mock_zip.return_value = testZip
+        mock_is_zipfile.return_value = True
         files = processFileUploads(files)
 
         self.assertEqual(len(files), 2)

--- a/media_service/tests/test_mediastore.py
+++ b/media_service/tests/test_mediastore.py
@@ -228,7 +228,6 @@ class MockZipFile:
     def write(self, fname):
         self.files.append(fname)
     def namelist(self):
-        print("namelist!!")
         names = []
         for name in self.files:
             names.append(name)

--- a/media_service/views.py
+++ b/media_service/views.py
@@ -10,7 +10,7 @@ from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnl
 from rest_framework.exceptions import PermissionDenied
 
 from media_service.models import Course, Collection, Resource, MediaStore, CollectionResource
-from media_service.mediastore import MediaStoreUpload, process_zip
+from media_service.mediastore import MediaStoreUpload, processFileUploads
 from media_service.iiif import CollectionManifestController
 from media_service.serializers import UserSerializer, CourseSerializer, ResourceSerializer, CollectionSerializer, CollectionResourceSerializer
 
@@ -183,7 +183,7 @@ class CourseImagesListView(GenericAPIView):
         response_data = []
         logger.debug("File uploads: %s" % request.FILES.getlist(file_param))
 
-        files = process_zip(request.FILES.getlist(file_param))
+        files = processFileUploads(request.FILES.getlist(file_param))
 
         for file_upload in files:
             logger.debug("Processing file upload: %s" % file_upload.name)


### PR DESCRIPTION
This resolves #15 

It adds the ability to send zip files to the API
Note: to use this in the LTI component, zips need to be allowed by the client.

- [x] accepts zip files
- [x] extracts zip files, processes all image files
- [x] refactor into module
- [x] unit test

@arthurian @MichaelDHilborn-Harvard  review!