### PR TITLE
bug on zip directories

### DIFF
--- a/media_service/mediastore.py
+++ b/media_service/mediastore.py
@@ -5,6 +5,7 @@ import tempfile
 import magic
 import logging
 import zipfile
+import re
 from django.conf import settings
 from django.core.files.images import get_image_dimensions
 from django.core.files.uploadedfile import UploadedFile
@@ -44,7 +45,7 @@ def processFileUploads(filelist):
                 newfile.name = f
 
                 # avoiding temp files added to archive
-                if "__MACOSX" not in newfile.name:
+                if "__MACOSX" not in newfile.name and not re.match(r".*\/$", newfile.name):
                     newlist.append(newfile)
         else:
             newlist.append(file)
@@ -247,6 +248,7 @@ class MediaStoreUpload:
         Returns the lowercase file extension (no dot). Example: "jpg" or "gif"
         '''
         name_parts = os.path.splitext(self.file.name)
+        logger.debug("getFileExtension: %s" % self.file.name)
         file_extension = ''
         if len(name_parts) > 1:
             file_extension = name_parts[1]

--- a/media_service/mediastore.py
+++ b/media_service/mediastore.py
@@ -39,14 +39,19 @@ def processFileUploads(filelist):
             # unzip and append to the list
             zip = zipfile.ZipFile(file, "r")
             for f in zip.namelist():
-                logger.debug("ZipFile content: %s" % f)
+                logger.debug("Extracting ZipFile: %s" % f)
+
+                if f.endswith('/'):
+                    logger.debug("Skipping directory entry: %s" % f)
+                    continue
+                if "__MACOSX" in f or ".DS_Store" in f:
+                    logger.debug("Skipping MAC OS X resource file artifact: %s" % f)
+                    continue
+                    
                 zf = zip.open(f).read()
                 newfile = File(io.BytesIO(zf))
                 newfile.name = f
-
-                # avoiding temp files added to archive
-                if "__MACOSX" not in newfile.name and not re.match(r".*\/$", newfile.name):
-                    newlist.append(newfile)
+                newlist.append(newfile)
         else:
             newlist.append(file)
 

--- a/media_service/tests/test_mediastore.py
+++ b/media_service/tests/test_mediastore.py
@@ -205,7 +205,6 @@ class TestZipUpload(unittest.TestCase):
     @patch('zipfile.is_zipfile')
     def testProcessFileUploads(self, mock_is_zipfile, mock_zip):
         testZip = MockZipFile()
-        print("this thing: %s" % self.test_files['test.png'])
         testZip.write(self.test_files['test.png']['filename'])
         testZip.write(self.test_files['empty.jpg']['filename'])
 
@@ -213,10 +212,14 @@ class TestZipUpload(unittest.TestCase):
         mock_zip.return_value = testZip
         mock_is_zipfile.return_value = True
         files = processFileUploads(files)
-
         self.assertEqual(len(files), 2)
         self.assertNotIn(testZip, files)
 
+        testZip.write('some_directory/')
+        files = [testZip]
+        files = processFileUploads(files)
+        self.assertEqual(len(files), 2)
+        self.assertNotIn('some_directory/', files)
 
 class MockZipFile:
     test_files = TEST_FILES

--- a/media_service/tests/test_mediastore.py
+++ b/media_service/tests/test_mediastore.py
@@ -205,8 +205,9 @@ class TestZipUpload(unittest.TestCase):
     @patch('zipfile.is_zipfile')
     def testProcessFileUploads(self, mock_is_zipfile, mock_zip):
         testZip = MockZipFile()
-        testZip.write(self.test_files['test.png'])
-        testZip.write(self.test_files['empty.jpg'])
+        print("this thing: %s" % self.test_files['test.png'])
+        testZip.write(self.test_files['test.png']['filename'])
+        testZip.write(self.test_files['empty.jpg']['filename'])
 
         files = [testZip]
         mock_zip.return_value = testZip


### PR DESCRIPTION
This PR fixes a bug where zip files with directories would fail

- [x] added a check for if it's a directory (how to make this better?)
- [x] regression test (is there a more explicit way to write this test?)

====

- [x] fix existing unit test

@arthurian @MichaelDHilborn-Harvard review please?