### PR TITLE
Bugfix/unicode

### DIFF
--- a/media_service/models.py
+++ b/media_service/models.py
@@ -239,7 +239,7 @@ class Collection(BaseModel, SortOrderModelMixin):
         super(Collection, self).save(*args, **kwargs)
 
     def __unicode__(self):
-        return "{0}:{1}".format(self.id, self.title)
+        return u'%s:%s' % (self.id, self.title)
 
     @classmethod
     def get_course_collections(cls, course_pk):

--- a/media_service/models.py
+++ b/media_service/models.py
@@ -118,7 +118,7 @@ class UserProfile(BaseModel):
         verbose_name_plural = 'user_profiles'
 
     def __unicode__(self):
-        return "UserProfile:%s" % self.id
+        return u'UserProfile:%s' % self.id
 
 class Course(BaseModel):
     title = models.CharField(max_length=255)
@@ -136,7 +136,7 @@ class Course(BaseModel):
         unique_together = ("lti_context_id", "lti_tool_consumer_instance_guid")
 
     def __unicode__(self):
-        return "{0}:{1}:{2}".format(self.id, self.lti_context_id, self.title)
+        return u'{0}:{1}:{2}'.format(self.id, self.lti_context_id, self.title)
 
 class Resource(BaseModel, SortOrderModelMixin):
     course = models.ForeignKey(Course, on_delete=models.CASCADE, related_name='resources')
@@ -215,7 +215,7 @@ class Resource(BaseModel, SortOrderModelMixin):
             return []
 
     def __unicode__(self):
-        return "{0}:{1}".format(self.id, self.title)
+        return u'{0}:{1}'.format(self.id, self.title)
 
     @classmethod
     def get_course_images(cls, course_pk):
@@ -262,7 +262,7 @@ class CollectionResource(BaseModel, SortOrderModelMixin):
         super(CollectionResource, self).save(*args, **kwargs)
 
     def __unicode__(self):
-        return "{0}".format(self.id)
+        return u'{0}'.format(self.id)
 
     @classmethod
     def get_collection_images(cls, collection_pk):

--- a/media_service/serializers.py
+++ b/media_service/serializers.py
@@ -162,6 +162,7 @@ class ResourceSerializer(serializers.HyperlinkedModelSerializer):
         upload_result = self.handle_file_upload()
         if 'upload_file_name' in upload_result:
             title = upload_result['upload_file_name']
+
         resource_attrs = {
             "course": course_id,
             "title": title,
@@ -172,6 +173,11 @@ class ResourceSerializer(serializers.HyperlinkedModelSerializer):
             "upload_file_name": upload_result['upload_file_name'],
             "is_upload": upload_result['is_upload'],
         }
+        
+        # Metadata cannot be null, so only include if it's non-null
+        if metadata is not None:
+            resource_attrs['metadata'] = metadata
+
         resource = Resource(**resource_attrs)
         resource.save()
         return resource

--- a/media_service/tests/test_models.py
+++ b/media_service/tests/test_models.py
@@ -21,15 +21,6 @@ class TestMediaStore(unittest.TestCase):
             "file_type": "image/gif",
             "img_width": 24,
             "img_height": 24,            
-        },
-        {
-            "file_name": u'январь.jpg',
-            "file_size": 1024,
-            "file_md5hash": '4213090cae0c1ad78285207ffe9fb456',
-            "file_extension": "jpg",
-            "file_type": "image/jpg",
-            "img_width": 800,
-            "img_height": 600,            
         }
     ]
     
@@ -69,7 +60,8 @@ class TestUnicodeInput(unittest.TestCase):
         titles = [
             'My Awesome Collection',
              u'January is "январь" in Russian',
-             u'New Year in Japanese: 新年'
+             u'New Year in Japanese: 新年',
+             'Yet another awesome collection'
         ]
         course = self._createCourse(lti_context_id=1)
         

--- a/media_service/tests/test_models.py
+++ b/media_service/tests/test_models.py
@@ -1,5 +1,6 @@
+# -*- coding: UTF-8 -*-
 import unittest
-from media_service.models import MediaStore
+from media_service.models import MediaStore, Collection, Course
 
 class TestMediaStore(unittest.TestCase):
     test_items = [
@@ -20,6 +21,15 @@ class TestMediaStore(unittest.TestCase):
             "file_type": "image/gif",
             "img_width": 24,
             "img_height": 24,            
+        },
+        {
+            "file_name": u'январь.jpg',
+            "file_size": 1024,
+            "file_md5hash": '4213090cae0c1ad78285207ffe9fb456',
+            "file_extension": "jpg",
+            "file_type": "image/jpg",
+            "img_width": 800,
+            "img_height": 600,            
         }
     ]
     
@@ -47,3 +57,28 @@ class TestMediaStore(unittest.TestCase):
             self.assertEqual(thumb_actual['width'], thumb_w)
             self.assertEqual(thumb_actual['height'], thumb_h)
             self.assertTrue(thumb_actual['url'])
+
+class TestUnicodeInput(unittest.TestCase):
+    
+    def _createCourse(self, lti_context_id=None):
+        course = Course(title="Test Course: %s" % lti_context_id, lti_context_id=lti_context_id, lti_tool_consumer_instance_guid="canavs")
+        course.save()
+        return course
+    
+    def test_collection_title(self):
+        titles = [
+            'My Awesome Collection',
+             u'January is "январь" in Russian',
+             u'New Year in Japanese: 新年'
+        ]
+        course = self._createCourse(lti_context_id=1)
+        
+        for title in titles:
+            collection = Collection(title=title, course=course)
+            collection.save()
+            self.assertEqual(collection.title, title)
+            try:
+                stringified_collection = str(collection)
+            except UnicodeEncodeError as e:
+                self.fail('Converting the collection object to a string raised UnicodeEncodeError: %s' % e)
+


### PR DESCRIPTION
This appears to fix the issue with unicode characters in the collection title and description. I didn't find any issues with unicode characters in image file names and/or metadata values.

@jazahn @MichaelDHilborn-Harvard Review?