### PR TITLE
bugfix/iiif-canvas-uniqueness

### DIFF
--- a/media_service/iiif.py
+++ b/media_service/iiif.py
@@ -53,7 +53,7 @@ class CollectionManifestController(object):
             self.manifest = self.create_manifest()
         if 'object_type' in self.request.GET and 'object_id' in self.request.GET:
             object_type = self.request.GET['object_type']
-            object_id = int(self.request.GET['object_id'])
+            object_id = self.request.GET['object_id']
             found_object = self.manifest.find_object(object_type, object_id)
             if found_object is None:
                 return None
@@ -208,6 +208,11 @@ class IIIFSequence(IIIFObject):
         self.canvases = []
 
     def add_canvas(self, canvas_id):
+        # Mirador relies on every canvas having a unique URI, so in case we have duplicate image
+        # objects in the manifest (i.e. duplicate canvases), we'll add an index to each canvas_id
+        # to ensure uniqueness within the manifest.
+        index = len(self.canvases)
+        canvas_id = "%s.%s" % (canvas_id, index)
         canvas = IIIFCanvas(self.manifest, canvas_id)
         self.canvases.append(canvas)
         return canvas
@@ -240,7 +245,7 @@ class IIIFCanvas(IIIFObject):
         self.resource = None
 
     def add_image(self, image):
-        self.resource = IIIFImageResource(self.manifest, image['id'], image['url'], image['is_link'])
+        self.resource = IIIFImageResource(self.manifest, self.id, image['url'], image['is_link'])
         if image['width'] is not None:
             self.width = image['width']
         if image['height'] is not None:

--- a/media_service/tests/test_iiif.py
+++ b/media_service/tests/test_iiif.py
@@ -94,8 +94,14 @@ class IIIFManifestTest(unittest.TestCase):
     def test_manifest_has_unique_canvas_ids(self):
         # create a new list of images with duplicates of first and last image
         images = self.get_images_list()
+        total_duplicates = 0
         for image_id in (images[0]['id'], images[-1]['id']):
-            self.duplicate_image(images, image_id, num_duplicates=3)
+            num_duplicates = 3
+            self.duplicate_image(images, image_id, num_duplicates)
+            total_duplicates += num_duplicates
+
+        # expect there to be duplicates added to the list
+        self.assertEqual(total_duplicates + len(self.get_images_list()), len(images))
         
         # generate manifest from the images
         manifest_id = 1
@@ -111,7 +117,5 @@ class IIIFManifestTest(unittest.TestCase):
             else:
                 dups.append(canvas_id)
         
-        # expect there to be no duplicate canvas IDs
+        # expect there to be no duplicate canvas IDs in the manifest
         self.assertEqual(0, len(dups))
-        
-    

--- a/media_service/tests/test_iiif.py
+++ b/media_service/tests/test_iiif.py
@@ -28,20 +28,40 @@ class IIIFManifestTest(unittest.TestCase):
         self.factory = RequestFactory()
 
     def create_manifest(self, manifest_id, **kwargs):
-        request = self.factory.get('/')
-        return request, IIIFManifest(manifest_id, **kwargs)
+        return IIIFManifest(manifest_id, **kwargs)
 
     def get_images_list(self):
         images = [
             {'id': 1, 'is_link': False, 'url': 'http://localhost:8000/loris/foo.jpg', 'label': 'foo.jpg', 'description': '', 'metadata': []},
             {'id': 2, 'is_link': False, 'url': 'http://localhost:8000/loris/bar.jpg', 'label': 'bar.jpg', 'description': '', 'metadata': []},
             {'id': 3, 'is_link': True, 'url': 'http://my.link/image.jpg', 'label': 'image.jpg', 'description': '', 'metadata': []},
+            {
+                'id': 4,
+                'is_link': False,
+                'url': 'http://localhost:8000/loris/foo_bar_foo.png',
+                'label': 'foo_bar_foo.png',
+                'description': 'Foo Bar with Foo Again',
+                'metadata': [
+                    {"label": "Date", "value": "Once upon a time..."},
+                    {"label": "Location", "value": "In a galaxy far far away..."},
+                ]
+            },
         ]
+        return images
+    
+    def duplicate_image(self, images, image_id, num_duplicates=1):
+        '''
+        Given a list of images, find an image by ID and duplicate it.
+        '''
+        image = next(iter([i for i in images if i['id'] == image_id]))
+        while num_duplicates > 0:
+            images.append(image)
+            num_duplicates -= 1
         return images
 
     def test_create_manifest_with_images(self):
         images = self.get_images_list()
-        request, manifest = self.create_manifest(1, images=self.get_images_list())
+        manifest = self.create_manifest(1, images=self.get_images_list())
         md = manifest.to_dict()
         
         non_link_images = [img for img in images if img['is_link'] is False]
@@ -55,7 +75,7 @@ class IIIFManifestTest(unittest.TestCase):
         label = 'test label'
         description = 'test description'
         manifest_id = 1
-        request, manifest = self.create_manifest(manifest_id, label=label, description=description)
+        manifest = self.create_manifest(manifest_id, label=label, description=description)
         md = manifest.to_dict()
         
         expected_attr = {
@@ -70,4 +90,28 @@ class IIIFManifestTest(unittest.TestCase):
         for key in expected_attr.keys():
             self.assertTrue(key in md, "manifest should have a %s attribute" % key)
             self.assertEqual(md[key], expected_attr[key])
+    
+    def test_manifest_has_unique_canvas_ids(self):
+        # create a new list of images with duplicates of first and last image
+        images = self.get_images_list()
+        for image_id in (images[0]['id'], images[-1]['id']):
+            self.duplicate_image(images, image_id, num_duplicates=3)
+        
+        # generate manifest from the images
+        manifest_id = 1
+        manifest_obj = self.create_manifest(manifest_id, images=images)
+        manifest_dict = manifest_obj.to_dict()
+
+        # search for duplicate canvas IDs
+        seen, dups = set(), []
+        for canvas in manifest_dict['sequences'][0]['canvases']:
+            canvas_id = canvas['@id']
+            if canvas_id not in seen:
+                seen.add(canvas_id)
+            else:
+                dups.append(canvas_id)
+        
+        # expect there to be no duplicate canvas IDs
+        self.assertEqual(0, len(dups))
+        
     


### PR DESCRIPTION
This fixes an issue where instructors added duplicate images to collections in the Media Manager, which caused Mirador to not work properly (navigating between images in the collection). Every canvas in the IIIF manifest must have a unique canvas ID in order for Mirador to work properly, so this PR ensures uniqueness by qualifying the canvas object IDs with an index.

@elliottyates Review?

---
[ATGU-549](https://jira.huit.harvard.edu/browse/ATGU-549)