### PR TITLE
bugfix/null-metadata

### DIFF
--- a/media_service/models.py
+++ b/media_service/models.py
@@ -138,6 +138,10 @@ class Course(BaseModel):
     def __unicode__(self):
         return u'{0}:{1}:{2}'.format(self.id, self.lti_context_id, self.title)
 
+
+def metadata_default():
+    return json.dumps([])
+
 class Resource(BaseModel, SortOrderModelMixin):
     course = models.ForeignKey(Course, on_delete=models.CASCADE, related_name='resources')
     owner = models.ForeignKey(UserProfile, on_delete=models.CASCADE, related_name='resources', null=True, blank=True)
@@ -153,7 +157,7 @@ class Resource(BaseModel, SortOrderModelMixin):
     thumb_height = models.PositiveIntegerField(null=True, blank=True)
     title = models.CharField(max_length=255)
     description = models.TextField(blank=True)
-    metadata = models.TextField(blank=True, default=json.dumps([]))
+    metadata = models.TextField(blank=True, default=metadata_default)
     sort_order = models.IntegerField(default=0)
 
     class Meta:
@@ -164,6 +168,8 @@ class Resource(BaseModel, SortOrderModelMixin):
     def save(self, *args, **kwargs):
         if not self.sort_order:
             self.sort_order = self.next_sort_order({"course__pk": self.course.pk})
+        if self.metadata == "null" or not self.metadata:
+            self.metadata = metadata_default()
         if self.media_store:
             self.media_store.reference_count += 1
             self.media_store.save() 

--- a/media_service/models.py
+++ b/media_service/models.py
@@ -139,9 +139,6 @@ class Course(BaseModel):
         return u'{0}:{1}:{2}'.format(self.id, self.lti_context_id, self.title)
 
 
-def metadata_default():
-    return json.dumps([])
-
 class Resource(BaseModel, SortOrderModelMixin):
     course = models.ForeignKey(Course, on_delete=models.CASCADE, related_name='resources')
     owner = models.ForeignKey(UserProfile, on_delete=models.CASCADE, related_name='resources', null=True, blank=True)
@@ -157,7 +154,7 @@ class Resource(BaseModel, SortOrderModelMixin):
     thumb_height = models.PositiveIntegerField(null=True, blank=True)
     title = models.CharField(max_length=255)
     description = models.TextField(blank=True)
-    metadata = models.TextField(blank=True, default=metadata_default)
+    metadata = models.TextField(blank=True, default=lambda: Resource.metadata_default)
     sort_order = models.IntegerField(default=0)
 
     class Meta:
@@ -169,7 +166,7 @@ class Resource(BaseModel, SortOrderModelMixin):
         if not self.sort_order:
             self.sort_order = self.next_sort_order({"course__pk": self.course.pk})
         if not (isinstance(self.metadata, basestring) and len(self.metadata) > 0 and '[]' == self.metadata[0] + self.metadata[-1]):
-            self.metadata = metadata_default()
+            self.metadata = self.metadata_default()
         if self.media_store:
             self.media_store.reference_count += 1
             self.media_store.save()
@@ -227,6 +224,11 @@ class Resource(BaseModel, SortOrderModelMixin):
     def get_course_images(cls, course_pk):
         images = cls.objects.filter(course__pk=course_pk).order_by('sort_order')
         return images
+
+    @staticmethod
+    def metadata_default():
+        return json.dumps([])
+
     
 class Collection(BaseModel, SortOrderModelMixin):
     title = models.CharField(max_length=255)

--- a/media_service/models.py
+++ b/media_service/models.py
@@ -168,11 +168,11 @@ class Resource(BaseModel, SortOrderModelMixin):
     def save(self, *args, **kwargs):
         if not self.sort_order:
             self.sort_order = self.next_sort_order({"course__pk": self.course.pk})
-        if self.metadata == "null" or not self.metadata:
+        if not (isinstance(self.metadata, basestring) and len(self.metadata) > 0 and '[]' == self.metadata[0] + self.metadata[-1]):
             self.metadata = metadata_default()
         if self.media_store:
             self.media_store.reference_count += 1
-            self.media_store.save() 
+            self.media_store.save()
         super(Resource, self).save(*args, **kwargs)
 
     def delete(self, *args, **kwargs):

--- a/media_service/serializers.py
+++ b/media_service/serializers.py
@@ -168,7 +168,6 @@ class ResourceSerializer(serializers.HyperlinkedModelSerializer):
             "title": title,
             "description": description,
             "owner": request.user.profile,
-            "metadata": json.dumps(metadata),
             "media_store": upload_result['media_store'],
             "upload_file_name": upload_result['upload_file_name'],
             "is_upload": upload_result['is_upload'],
@@ -176,7 +175,7 @@ class ResourceSerializer(serializers.HyperlinkedModelSerializer):
         
         # Metadata cannot be null, so only include if it's non-null
         if metadata is not None:
-            resource_attrs['metadata'] = metadata
+            resource_attrs['metadata'] = json.dumps(metadata)
 
         resource = Resource(**resource_attrs)
         resource.save()

--- a/media_service/tests/test_models.py
+++ b/media_service/tests/test_models.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 import unittest
 import json
-from media_service.models import MediaStore, Collection, Course, Resource, metadata_default
+from media_service.models import MediaStore, Collection, Course, Resource
 
 class TestMediaStore(unittest.TestCase):
     test_items = [
@@ -61,7 +61,7 @@ class TestResource(unittest.TestCase):
     def test_save_with_metadata(self):
         title = "Test Resource"
         course = TestResource.test_course
-        default_metadata = metadata_default()
+        default_metadata = Resource.metadata_default()
         missing_metadata = ["", None]
         invalid_metadata = [json.dumps(v) for v in None, True, False, 123, {}]
         valid_metadata = [json.dumps(v) for v in [], [{"label":"X", "value": "Y"}]]

--- a/media_service/tests/test_models.py
+++ b/media_service/tests/test_models.py
@@ -62,9 +62,9 @@ class TestResource(unittest.TestCase):
         title = "Test Resource"
         course = TestResource.test_course
         default_metadata = Resource.metadata_default()
-        missing_metadata = ["", None]
-        invalid_metadata = [json.dumps(v) for v in None, True, False, 123, {}]
-        valid_metadata = [json.dumps(v) for v in [], [{"label":"X", "value": "Y"}]]
+        missing_metadata = ("", None)
+        invalid_metadata = (None, True, False, 123, {})
+        valid_metadata = ([], [{"label":"X", "value": "Y"}])
         
         # check that missing or invalid metadata values are saved using the default value
         # for example the string "null" is not a valid value, so it should be overwritten with "[]"
@@ -76,9 +76,9 @@ class TestResource(unittest.TestCase):
         
         # check that valid metadata is saved unchanged
         for metadata in valid_metadata:
-            instance = Resource(course=course, title=title, metadata=metadata)
+            instance = Resource(course=course, title=title, metadata=json.dumps(metadata))
             instance.save()
-            self.assertEqual(metadata, instance.metadata)
+            self.assertEqual(json.dumps(metadata), instance.metadata)
 
 class TestUnicodeInput(unittest.TestCase):
     


### PR DESCRIPTION
Fixes issue with `"null"` being saved for metadata instead of the expected default value. This will ensure that existing instances with that value will be saved correctly along with any new instances.

@elliottyates Review?

---
[ATGU-559](https://jira.huit.harvard.edu/browse/ATGU-559)