### PR TITLE
feature/add-web-image

### DIFF
--- a/media_management_api/requirements/base.txt
+++ b/media_management_api/requirements/base.txt
@@ -5,11 +5,12 @@ psycopg2==2.6.1
 redis==2.10.3
 django-redis-cache==1.5.3
 hiredis==0.2.0
-djangorestframework==3.3.1
+djangorestframework==3.4.7
 markdown==2.6.5
 mock==1.3.0
 django-filter==0.11.0
 django-cors-headers==0.11
 boto==2.38.0
-pillow==3.0.0
-python-magic==0.4.10
+pillow==3.4.2
+python-magic==0.4.13
+requests==2.13.0

--- a/media_service/mediastore.py
+++ b/media_service/mediastore.py
@@ -77,7 +77,7 @@ def processRemoteImages(items):
             raise MediaStoreException("Missing 'url' for item %d in list of items: %s" % (index, items))
         data = {
             "title": item.get("title", "Untitled") or "Untitled",
-            "description": item.get("description", "Image retrieved from %s" % url),
+            "description": item.get("description", ""),
         }
         image_file = fetchRemoteImage(url)
         processed[url] = {

--- a/media_service/mediastore.py
+++ b/media_service/mediastore.py
@@ -64,7 +64,7 @@ def fetchRemoteImage(url):
     extension = guessImageExtensionFromUrl(url)
     suffix = '' if extension is None else '.' + extension
     f = tempfile.TemporaryFile(suffix=suffix)
-    res = requests.get(url)
+    res = requests.get(url, verify=False)
     logger.debug("Fetched remote image [%s]. Response status=%s headers=%s" % (url, res.status_code, res.headers))
 
     res.raise_for_status()

--- a/media_service/mediastore.py
+++ b/media_service/mediastore.py
@@ -38,7 +38,6 @@ VALID_IMAGE_EXT_FOR_TYPE = {
     'image/pdf': 'pdf',
 }
 VALID_IMAGE_TYPES = sorted(VALID_IMAGE_EXT_FOR_TYPE.keys())
-VALID_IMAGE_TYPES_DISPLAY = [t.replace('image/', '') for t in VALID_IMAGE_TYPES]
 
 class MediaStoreException(Exception):
     pass
@@ -215,9 +214,8 @@ class MediaStoreUpload:
 
     def validateImageType(self):
         filetype = self.getFileType()
-        valid_types = VALID_IMAGE_TYPES
-        if filetype not in valid_types:
-            errmsg = "Image type '%s' is invalid, must be one of %s." % (filetype, valid_types)
+        if filetype not in VALID_IMAGE_TYPES:
+            errmsg = "Image type '%s' is not supported. Please ensure the image is one of the supported image types." %  filetype
             self.error('type', errmsg)
             if self._raise_for_error:
                 raise MediaStoreException(errmsg)
@@ -229,9 +227,8 @@ class MediaStoreUpload:
         Validates that the image extension is valid.
         '''
         ext = self.getFileExtension()
-        valid_exts = VALID_IMAGE_EXTENSIONS
-        if ext not in valid_exts:
-            errmsg = "Image extension '%s' is invalid, must be one of %s. " % (ext, valid_exts)
+        if ext not in VALID_IMAGE_EXTENSIONS:
+            errmsg = "Image extension '%s' is not recognized." % ext
             self.error('extension', errmsg)
             if self._raise_for_error:
                 raise MediaStoreException(errmsg)
@@ -245,7 +242,7 @@ class MediaStoreUpload:
         try:
             Image.open(self.file)
         except Exception as e:
-            errmsg = "Image cannot be opened or identified [%s]. " % str(e)
+            errmsg = "Image cannot be opened or identified."
             self.error('open', errmsg)
             if self._raise_for_error:
                 raise MediaStoreException(errmsg)

--- a/media_service/mediastore.py
+++ b/media_service/mediastore.py
@@ -70,7 +70,7 @@ def fetchRemoteImage(url):
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36',
 
         # Make explicit the image types we are willing to accept
-        'Accept': "{image_types}".format(image_types=', '.join(VALID_IMAGE_TYPES)),
+        'Accept': "{image_types},image/*;q=0.8".format(image_types=', '.join(VALID_IMAGE_TYPES)),
     }
 
     # Use HTTP for all requests because of SSL errors

--- a/media_service/migrations/0004_auto_20170329_1530.py
+++ b/media_service/migrations/0004_auto_20170329_1530.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import media_service.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('media_service', '0003_resource_metadata'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='resource',
+            old_name='upload_file_name',
+            new_name='original_file_name',
+        ),
+        migrations.AlterField(
+            model_name='resource',
+            name='img_height',
+            field=models.PositiveIntegerField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='resource',
+            name='img_type',
+            field=models.CharField(max_length=128, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='resource',
+            name='img_url',
+            field=models.CharField(max_length=4096, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='resource',
+            name='img_width',
+            field=models.PositiveIntegerField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='resource',
+            name='metadata',
+            field=models.TextField(default=media_service.models.metadata_default, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='resource',
+            name='thumb_height',
+            field=models.PositiveIntegerField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='resource',
+            name='thumb_url',
+            field=models.CharField(max_length=4096, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='resource',
+            name='thumb_width',
+            field=models.PositiveIntegerField(null=True, blank=True),
+        ),
+    ]

--- a/media_service/models.py
+++ b/media_service/models.py
@@ -82,11 +82,11 @@ class MediaStore(BaseModel):
             thumb_h = h
             thumb_w = w
         return thumb_w, thumb_h
-    
+
     def get_iiif_identifier(self, encode=False):
         identifier = "{bucket}/{keyname}".format(bucket=AWS_S3_BUCKET, keyname=self.get_s3_keyname())
         if encode:
-            identifier = urllib.quote(identifier, safe='') # Make sure "/" is percent-encoded too!        
+            identifier = urllib.quote(identifier, safe='') # Make sure "/" is percent-encoded too!
         return identifier
 
     def get_iiif_base_url(self):
@@ -138,13 +138,15 @@ class Course(BaseModel):
     def __unicode__(self):
         return u'{0}:{1}:{2}'.format(self.id, self.lti_context_id, self.title)
 
+def metadata_default():
+    return json.dumps([])
 
 class Resource(BaseModel, SortOrderModelMixin):
     course = models.ForeignKey(Course, on_delete=models.CASCADE, related_name='resources')
     owner = models.ForeignKey(UserProfile, on_delete=models.CASCADE, related_name='resources', null=True, blank=True)
     media_store = models.ForeignKey(MediaStore, null=True, on_delete=models.SET_NULL)
     is_upload = models.BooleanField(default=True, null=False)
-    upload_file_name = models.CharField(max_length=4096, null=True)
+    original_file_name = models.CharField(max_length=4096, null=True)
     img_type = models.CharField(max_length=128, null=True, blank=True)
     img_url = models.CharField(max_length=4096, null=True, blank=True)
     img_width = models.PositiveIntegerField(null=True, blank=True)
@@ -154,7 +156,7 @@ class Resource(BaseModel, SortOrderModelMixin):
     thumb_height = models.PositiveIntegerField(null=True, blank=True)
     title = models.CharField(max_length=255)
     description = models.TextField(blank=True)
-    metadata = models.TextField(blank=True, default=lambda: Resource.metadata_default)
+    metadata = models.TextField(blank=True, default=metadata_default)
     sort_order = models.IntegerField(default=0)
 
     class Meta:
@@ -170,9 +172,9 @@ class Resource(BaseModel, SortOrderModelMixin):
         # Note that rigorous validation of the data structure happens in the serializer. A better
         # solution would be to implement a true "JSONField" with rigorous validation on the model.
         try:
-            self.metadata = self.metadata if isinstance(json.loads(self.metadata), list) else self.metadata_default()
+            self.metadata = self.metadata if isinstance(json.loads(self.metadata), list) else metadata_default()
         except (TypeError, ValueError):
-            self.metadata = self.metadata_default()
+            self.metadata = metadata_default()
 
         if self.media_store:
             self.media_store.reference_count += 1
@@ -183,8 +185,8 @@ class Resource(BaseModel, SortOrderModelMixin):
     def delete(self, *args, **kwargs):
         if self.media_store:
             self.media_store.reference_count -= 1
-            self.media_store.save() 
-        super(Resource, self).delete(*args, **kwargs)    
+            self.media_store.save()
+        super(Resource, self).delete(*args, **kwargs)
 
     def get_representation(self):
         if self.media_store is None:
@@ -218,7 +220,7 @@ class Resource(BaseModel, SortOrderModelMixin):
             "iiif_base_url": iiif_base_url,
         }
         return data
-    
+
     def load_metadata(self):
         try:
             return json.loads(self.metadata)
@@ -233,11 +235,7 @@ class Resource(BaseModel, SortOrderModelMixin):
         images = cls.objects.filter(course__pk=course_pk).order_by('sort_order')
         return images
 
-    @staticmethod
-    def metadata_default():
-        return json.dumps([])
 
-    
 class Collection(BaseModel, SortOrderModelMixin):
     title = models.CharField(max_length=255)
     description = models.TextField(blank=True)

--- a/media_service/tests/test_mediastore.py
+++ b/media_service/tests/test_mediastore.py
@@ -244,6 +244,8 @@ class TestUrlImport(unittest.TestCase):
             self.assertEqual(processed[url]["data"]["title"], item["title"])
             if "description" in item:
                 self.assertEqual(processed[url]["data"]["description"], item["description"])
+            else:
+                self.assertEqual(processed[url]["data"]["description"], "")
 
 class TestZipUpload(unittest.TestCase):
 

--- a/media_service/tests/test_mediastore.py
+++ b/media_service/tests/test_mediastore.py
@@ -2,9 +2,13 @@ import unittest
 import base64
 import re
 import zipfile
+import tempfile
+import mock
+import requests
 from mock import MagicMock, patch
 from django.core.files.uploadedfile import SimpleUploadedFile
-from media_service.mediastore import MediaStoreUpload, MediaStoreUploadException, processFileUploads
+from media_service import mediastore
+from media_service.mediastore import MediaStoreUpload, MediaStoreException
 from media_service.models import MediaStore
 
 TEST_FILES = {
@@ -143,7 +147,7 @@ class TestMediaStoreUpload(unittest.TestCase):
 
         with self.assertRaises(Exception) as context:
             media_store_upload.getS3FileKey()
-        self.assertTrue(isinstance(context.exception, MediaStoreUploadException))
+        self.assertTrue(isinstance(context.exception, MediaStoreException))
 
         media_store = media_store_upload.save()
         self.assertTrue(media_store_upload.getS3FileKey())
@@ -185,8 +189,8 @@ class TestMediaStoreUpload(unittest.TestCase):
     def testInvalidImage(self):
         test_file = self.test_files['empty.jpg']
         media_store_upload = self.createMediaStoreUpload(test_file)
-        self.assertTrue(media_store_upload.validateImageExtension())
         self.assertFalse(media_store_upload.validateImageOpens())
+        self.assertTrue(media_store_upload.validateImageExtension())
         self.assertFalse(media_store_upload.isValid())
 
     def testImageJpegExtensionNormalized(self):
@@ -196,6 +200,50 @@ class TestMediaStoreUpload(unittest.TestCase):
         self.assertEqual(media_store_upload.getFileExtension(), normalized_jpeg_extension)
         self.assertTrue(media_store_upload.validateImageExtension())
 
+class TestUtilFunctions(unittest.TestCase):
+    def testGuessImageExtensionFromUrl(self):
+        def guess(url):
+            ''' Short wrapper function, purely for convenience and concise asserts...'''
+            return mediastore.guessImageExtensionFromUrl(url)
+        self.assertEqual("jpeg", guess('https://example.com/profile_images/466953024271679488/3rftwYWT.jpeg'))
+        self.assertEqual("jpg", guess('https://example.com/commons/thumb/c/c7/Harvard_square_harvard_yard.JPG/300px-Harvard_square_harvard_yard.JPG'))
+        self.assertEqual("gif", guess('http://example.com/static/xyz/files/horizontal_large_nobg.gif?m=1489563850&_q=1'))
+        self.assertEqual("png", guess('https://site.example.com/sites/default/files/_landing_carousel/Ext-538-carousel.png'))
+        self.assertEqual(None, guess('http://static1.example.com/static/5581f1f1e4b0be63c4780f1a/t/5584a36c/?format=1500w'))
+
+class TestUrlImport(unittest.TestCase):
+    def mockFetchRemoteImage(self):
+        '''
+        Returns a function mocking mediastore.fetchRemoteImage()
+        so that it always returns a dummy file.
+        '''
+        temp_image_file = tempfile.NamedTemporaryFile(mode='r')
+        def mock_fetch(url):
+            return temp_image_file
+        return mock_fetch
+
+    @patch('media_service.mediastore.fetchRemoteImage')
+    def testProcessRemoteImages(self, mock_fetch):
+        mock_fetch.return_value = self.mockFetchRemoteImage()
+        request_data = {
+            "items": [
+                {"url": "http://example.com/logo.jpg", "title": "Logo"},
+                {"url": "http://example.com/logo2.png", "title": "Logo2", "description": "Another logo"},
+            ]
+        }
+
+        processed = mediastore.processRemoteImages(request_data['items'])
+        self.assertTrue(processed is not None)
+        self.assertEqual(len(processed), len(request_data['items']))
+        for item in request_data['items']:
+            url = item['url']
+            self.assertTrue(url in processed)
+            self.assertEqual(sorted(processed[url].keys()), ["data", "file"])
+            expected_data = {"title": item["title"]}
+            self.assertEqual(sorted(processed[url]["data"].keys()), ["description", "title"])
+            self.assertEqual(processed[url]["data"]["title"], item["title"])
+            if "description" in item:
+                self.assertEqual(processed[url]["data"]["description"], item["description"])
 
 class TestZipUpload(unittest.TestCase):
 
@@ -211,13 +259,13 @@ class TestZipUpload(unittest.TestCase):
         files = [testZip]
         mock_zip.return_value = testZip
         mock_is_zipfile.return_value = True
-        files = processFileUploads(files)
+        files = mediastore.processFileUploads(files)
         self.assertEqual(len(files), 2)
         self.assertNotIn(testZip, files)
 
         testZip.write('some_directory/')
         files = [testZip]
-        files = processFileUploads(files)
+        files = mediastore.processFileUploads(files)
         self.assertEqual(len(files), 2)
         self.assertNotIn('some_directory/', files)
 

--- a/media_service/tests/test_models.py
+++ b/media_service/tests/test_models.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 import unittest
 import json
-from media_service.models import MediaStore, Collection, Course, Resource
+from media_service.models import MediaStore, Collection, Course, Resource, metadata_default
 
 class TestMediaStore(unittest.TestCase):
     test_items = [
@@ -61,7 +61,7 @@ class TestResource(unittest.TestCase):
     def test_save_with_metadata(self):
         title = "Test Resource"
         course = TestResource.test_course
-        default_metadata = Resource.metadata_default()
+        default_metadata = metadata_default()
         missing_metadata = ("", None)
         invalid_metadata = (None, True, False, 123, {})
         valid_metadata = ([], [{"label":"X", "value": "Y"}])

--- a/media_service/tests/test_views.py
+++ b/media_service/tests/test_views.py
@@ -38,7 +38,7 @@ class TestCourseEndpoint(APITestCase):
                         "description": "",
                         "metadata": "[]",
                         "sort_order": 0,
-                        "upload_file_name": None,
+                        "original_file_name": None,
                         "created": "2015-12-15T15:42:33.443434Z",
                         "updated": "2015-12-15T15:42:33.443434Z",
                         "type": "courseimages",
@@ -78,14 +78,14 @@ class TestCourseEndpoint(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), len(courses))
-        
+
         # Example of what we would expect
         example_item = self.get_example_item()
         expected_keys = sorted(example_item.keys())
         for course_data in response.data:
             actual_keys = sorted(course_data.keys())
             self.assertEqual(actual_keys, expected_keys)
-    
+
     def test_course_detail(self):
         pk = 1
         course = Course.objects.get(pk=pk)
@@ -96,14 +96,14 @@ class TestCourseEndpoint(APITestCase):
         # Get an example response item
         example_item = self.get_example_item(detail=True)
         expected_keys = sorted(example_item.keys())
-        
+
         # Check course attributes
         nested_keys = ("images", "collections")
         course_keys = sorted([k for k in response.data if k not in nested_keys])
         expected_course_keys = sorted([k for k in example_item.keys() if k not in nested_keys])
         self.assertEqual(course_keys, expected_course_keys)
         self.assertTrue(all([ k in response.data for k in nested_keys ]))
-        
+
         # Check nested items
         for nested_key in nested_keys:
             self.assertTrue(len(example_item[nested_key]) > 0)
@@ -115,7 +115,7 @@ class TestCourseEndpoint(APITestCase):
     def test_create_course(self):
         url = reverse('course-list')
         body = {
-            "title": "Test Course", 
+            "title": "Test Course",
             "lti_context_id": "e4d7f1b4ed2e42d15898f4b27b019da4",
             "lti_tool_consumer_instance_guid": "test.localhost"
         }
@@ -145,14 +145,14 @@ class TestCourseEndpoint(APITestCase):
         body = {
             "title": "Title Updated(!)",
             "lti_context_id": "updated_context_id",
-            "lti_tool_consumer_instance_guid": "updated_guid" 
+            "lti_tool_consumer_instance_guid": "updated_guid"
         }
 
         # Show that our update differs from the existing course object
         course_before_update = Course.objects.get(pk=pk)
         for f in body:
             self.assertNotEqual(getattr(course_before_update, f), body[f])
-        
+
         # Do the update
         response = self.client.put(url, body)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -168,7 +168,7 @@ class TestCourseEndpoint(APITestCase):
         pk = 1
         url = reverse('course-collections', kwargs={"pk": pk})
         body = {
-            "title": "Test Collection", 
+            "title": "Test Collection",
             "description": "Some description",
         }
 
@@ -184,7 +184,7 @@ class TestCourseEndpoint(APITestCase):
         for f in body:
             self.assertEqual(response.data[f], body[f])
             self.assertEqual(getattr(created_collection, f), body[f])
-    
+
 class TestCollectionEndpoint(APITestCase):
     fixtures = ['test.json']
 
@@ -200,7 +200,7 @@ class TestCollectionEndpoint(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), len(collections))
-        
+
         # Example of what we would expect
         example_item = {
             "url": "http://localhost:8000/collections/1",
@@ -249,7 +249,7 @@ class TestCollectionEndpoint(APITestCase):
     def test_create_collection(self):
         url = reverse('collection-list')
         body = {
-            "title": "Test Collection", 
+            "title": "Test Collection",
             "description": "Some description",
             "course_id": 1,
         }
@@ -296,4 +296,3 @@ class TestCollectionEndpoint(APITestCase):
 
         course_image_ids = collection_after_update.resources.values_list('resource__pk', flat=True)
         self.assertSequenceEqual(response.data['course_image_ids'], course_image_ids)
-


### PR DESCRIPTION
This PR modifies the `/courses/{pk}/images` endpoint to accept a JSON request containing image URLs to import. This complements its existing ability to accept a multipart file upload request.

Example JSON request:

```json
POST /courses/123/images
{
   "items":[
      {
         "url":"https://example.com/files/36/17/740e79.jpg",
         "title":"My Image Title"
      }
   ]
}
```