### PR TITLE
ATGU-1173: Fix HTTPS urls when adding image from the web

### DIFF
--- a/media_management_api/media_service/mediastore.py
+++ b/media_management_api/media_service/mediastore.py
@@ -70,11 +70,7 @@ def fetchRemoteImage(url):
         'Accept': "{image_types},image/*;q=0.8".format(image_types=', '.join(VALID_IMAGE_TYPES)),
     }
 
-    # Check to see if the URL is available using a HEAD request
-    res = requests.head(url, headers=request_headers)
-    if res.status_code == 404 and url.startswith("https://"):
-        url = "http://" + url[8:]
-
+    # Fetch the requested URL (could be HTTP or HTTPS)
     with contextlib.closing(requests.get(url, headers=request_headers, stream=True, verify=False)) as res:
         logger.debug("Fetched remote image. Request url=%s headers=%s Response code=%s headers=%s" % (url, request_headers, res.status_code, res.headers))
         res.raise_for_status()

--- a/media_management_api/media_service/mediastore.py
+++ b/media_management_api/media_service/mediastore.py
@@ -70,8 +70,10 @@ def fetchRemoteImage(url):
         'Accept': "{image_types},image/*;q=0.8".format(image_types=', '.join(VALID_IMAGE_TYPES)),
     }
 
-    # Use HTTP for all requests because of SSL errors
-    url = "http://" + url[8:] if url.startswith("https://") else url
+    # Check to see if the URL is available using a HEAD request
+    res = requests.head(url, headers=request_headers)
+    if res.status_code == 404 and url.startswith("https://"):
+        url = "http://" + url[8:]
 
     with contextlib.closing(requests.get(url, headers=request_headers, stream=True, verify=False)) as res:
         logger.debug("Fetched remote image. Request url=%s headers=%s Response code=%s headers=%s" % (url, request_headers, res.status_code, res.headers))

--- a/media_management_api/media_service/tests/test_mediastore.py
+++ b/media_management_api/media_service/tests/test_mediastore.py
@@ -247,6 +247,8 @@ class TestUrlImport(unittest.TestCase):
             else:
                 self.assertEqual(processed[url]["data"]["description"], "")
 
+
+
 class TestZipUpload(unittest.TestCase):
 
     test_files = TEST_FILES


### PR DESCRIPTION
This PR fixes an issue with HTTPS URLs that were being forced to the HTTP protocol, but the HTTP protocol was not supported. The fix was to remove the line that was changing HTTPS to HTTP.

Note that when we tested on the dev server, we did not find any issues with HTTPS URLs.

Example:

https://www.dl.ndl.go.jp/api/iiif/1311782/F0000001/full/full/0/default.jpg

@brandonATG @joshuagetega 

---
See also: [ATGU-1173](https://jira.huit.harvard.edu/browse/ATGU-1173)