### PR TITLE
Upgrade to django 2.1

### DIFF
--- a/media_management_api/requirements/base.txt
+++ b/media_management_api/requirements/base.txt
@@ -1,4 +1,4 @@
-Django~=2.0.0
+Django~=2.1.0
 psycopg2==2.8.4
 redis==2.10.3
 django-redis-cache==1.7.1


### PR DESCRIPTION
This PR resolves ATGU-2422 by:
- Incrementing the version of django

Notes:
- This PR is shocking
- I believe there are so few changes because I took a lot of time in the last upgrade to go over the deprecation lists from django 1.10 forward
- This [release](https://docs.djangoproject.com/en/3.0/releases/2.1/) also has very few changes to it anyways
- It passes all tests, and media_management_lit (dev) and annotationsx (dev) appear to be working as normal