### PR TITLE
Upgrade django requirement to django 2.2

### DIFF
--- a/media_management_api/requirements/base.txt
+++ b/media_management_api/requirements/base.txt
@@ -1,4 +1,4 @@
-Django~=2.1.0
+Django~=2.2.0
 psycopg2==2.8.4
 redis==2.10.3
 django-redis-cache==1.7.1


### PR DESCRIPTION
This PR resolves ATGU-2443 by:

- upgrading the version of django to 2.2

Notes:

- This PR seems to be identical to the last one
- There were very few changes in this release, and none of the current deprecations apply in this project