### PR TITLE
Image export

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ $ docker-compose exec web python manage.py createsuperuser
 $ open http://localhost:8000
 ```
 
+**If you have created the docker image yet before the previous step**
+```
+$ docker build -t harvard-atg/media_management_api
+$ docker tag harvard-atg/media_management_api:latest harvard-atg/media_management_api:dev
+```
+
 **Other tasks:**
 
 - Access postgres database: `docker-compose exec db psql -U media_management_api`

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ $ cp media_management_api/settings/secure.py.example media_management_api/settin
 $ docker-compose up
 $ docker-compose exec web python manage.py migrate
 $ docker-compose exec web python manage.py createsuperuser
-$ open http://localhost:8000
+$ open http://localhost:9000
 ```
 
-**If you have created the docker image yet before the previous step**
+**If you have not created the docker image yet before the previous step**
 ```
-$ docker build -t harvard-atg/media_management_api
+$ docker build -t harvard-atg/media_management_api .
 $ docker tag harvard-atg/media_management_api:latest harvard-atg/media_management_api:dev
 ```
 

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">70%</text>
-        <text x="80" y="14">70%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">71%</text>
+        <text x="80" y="14">71%</text>
     </g>
 </svg>

--- a/media_management_api/media_service/serializers.py
+++ b/media_management_api/media_service/serializers.py
@@ -190,7 +190,7 @@ class CsvExportResourceSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Resource
-        fields = ('url', 'id', 'title', 'iiif_url', 'metadata')
+        fields = ('url', 'id', 'title', 'description','iiif_url', 'metadata')
 
     def get_iiif_url(self, resource):
         if resource.media_store:

--- a/media_management_api/media_service/serializers.py
+++ b/media_management_api/media_service/serializers.py
@@ -8,6 +8,7 @@ import json
 def resource_to_representation(resource):
     return resource.get_representation()
 
+
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = User
@@ -180,6 +181,22 @@ def metadata_validator(value):
                 raise serializers.ValidationError("Metadata pair '%s' invalid. Must contain keys: label, value" % pair)
             if not isinstance(pair['label'], str) or not isinstance(pair['value'], str):
                 raise serializers.ValidationError("Metadata pair '%s' invalid. Label and value must be strings, not composite types." % pair)
+
+
+class CsvExportResourceSerializer(serializers.HyperlinkedModelSerializer):
+    url = serializers.HyperlinkedIdentityField(view_name="api:image-detail", lookup_field="pk")
+    metadata = serializers.JSONField(binary=False, required=False, allow_null=True, validators=[metadata_validator])
+    iiif_url = serializers.SerializerMethodField() # implicitly refers to get_iiif_url :(
+
+    class Meta:
+        model = Resource
+        fields = ('url', 'id', 'title', 'iiif_url', 'metadata')
+
+    def get_iiif_url(self, resource):
+        if resource.media_store:
+            return resource.media_store.get_iiif_full_url(thumb=False)
+        return None
+
 
 class ResourceSerializer(serializers.HyperlinkedModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name="api:image-detail", lookup_field="pk")

--- a/media_management_api/media_service/tests/test_views.py
+++ b/media_management_api/media_service/tests/test_views.py
@@ -220,6 +220,24 @@ class TestCourseEndpoint(BaseApiTestCase):
             self.assertEqual(response.data[f], body[f])
             self.assertEqual(getattr(course_after_update, f), body[f])
 
+    def test_course_images_list(self):
+        self.client.force_authenticate(self.superuser)
+
+        pk = 1
+        url = reverse('api:course-images', kwargs={"pk": pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()[0]['url'], 'http://testserver/api/images/1')
+
+    def test_course_images_csv(self):
+        self.client.force_authenticate(self.superuser)
+
+        pk = 1
+        url = reverse('api:course-images-csv', kwargs={"pk": pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response['content-type'], 'text/csv; charset=utf-8')
+
     def test_add_collection_to_course(self):
         self.client.force_authenticate(self.superuser)
 

--- a/media_management_api/media_service/tests/test_views.py
+++ b/media_management_api/media_service/tests/test_views.py
@@ -1,3 +1,5 @@
+import csv
+import io
 import unittest
 from django.urls import reverse
 from django.contrib.auth.models import User
@@ -235,8 +237,15 @@ class TestCourseEndpoint(BaseApiTestCase):
         pk = 1
         url = reverse('api:course-images-csv', kwargs={"pk": pk})
         response = self.client.get(url)
+        content = response.content.decode('utf-8')
+        cvs_reader = csv.reader(io.StringIO(content))
+        body = list(cvs_reader)
+        headers = body.pop(0)
+        index_of_url = headers.index('url')
+        
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response['content-type'], 'text/csv; charset=utf-8')
+        self.assertEqual(body[0][index_of_url], 'http://testserver/api/images/1')
 
     def test_add_collection_to_course(self):
         self.client.force_authenticate(self.superuser)

--- a/media_management_api/media_service/urls.py
+++ b/media_management_api/media_service/urls.py
@@ -45,6 +45,7 @@ urlpatterns = [
     path('courses/<int:pk>/course_copy', views.CourseCopyView.as_view(), name='course-clones'),
     path('courses/<int:pk>/collections', views.CourseCollectionsView.as_view(), name='course-collections'),
     path('courses/<int:pk>/images', views.CourseImagesListView.as_view(), name='course-images'),
+    path('courses/<int:pk>/library_export', views.CourseImagesListCsvExportView.as_view(), name='course-images-csv'),
     path('collections', collection_list, name='collection-list'),
     path('collections/<int:pk>', collection_detail, name='collection-detail'),
     path('collections/<int:pk>/images', views.CollectionImagesListView.as_view(), name='collectionimages-list'),

--- a/media_management_api/media_service/views.py
+++ b/media_management_api/media_service/views.py
@@ -8,7 +8,6 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.parsers import JSONParser, FormParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.settings import api_settings
 from rest_framework_csv.renderers import CSVRenderer
 
 from .filters import IsCourseUserFilterBackend

--- a/media_management_api/media_service/views.py
+++ b/media_management_api/media_service/views.py
@@ -8,12 +8,14 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.parsers import JSONParser, FormParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.settings import api_settings
+from rest_framework_csv.renderers import CSVRenderer
 
 from .filters import IsCourseUserFilterBackend
 from .permissions import IsCourseUserAuthenticated
 from .models import Course, Collection, Resource, CollectionResource, CourseCopy, CourseUser
 from .mediastore import processFileUploads, processRemoteImages
-from .serializers import CourseSerializer, ResourceSerializer, CollectionSerializer, CollectionResourceSerializer, CourseCopySerializer
+from .serializers import CourseSerializer, ResourceSerializer, CollectionSerializer, CollectionResourceSerializer, CourseCopySerializer, CsvExportResourceSerializer
 
 import logging
 
@@ -41,6 +43,7 @@ Courses Endpoints
 - `/courses/{pk}/course_copy` Lists a course's copy records
 - `/courses/{pk}/collections` Lists a course's collections
 - `/courses/{pk}/images`  Lists a course's images
+- `/courses/{pk}/library_export` Exports a course's images data to CSV
 
 Querying the list of courses
 ----------------------------
@@ -526,6 +529,45 @@ Methods
         msg = "Deleted %s images in course %s" % (num_deleted, course_pk)
         logger.info(msg)
         return Response({"message": msg})
+
+
+class CourseImagesListCsvExportView(GenericAPIView):
+    '''
+A **course images** resource is a set of *images* that belong to a *course*.
+This is also referred to as the course's image library.
+
+Endpoints
+----------------
+
+- `/courses/{pk}/library_export`
+
+Methods
+-------
+
+- `GET /courses/{pk}/library_export`  Exports images that belong to the course
+
+    '''
+    serializer_class = CsvExportResourceSerializer
+    queryset = Resource.objects.select_related('course', 'media_store')
+    # there is no browseable api renderer for this view
+    # by using CSVRender as the only format, you remove the '?format=csv' query parameters from 
+    # the url field in the output
+    renderer_classes = (CSVRenderer, )
+    permission_classes = (IsCourseUserAuthenticated,)
+    filter_backends = (IsCourseUserFilterBackend,)
+    course_user_filter_key = "course__pk__in"
+
+    def get_queryset(self):
+        queryset = super(CourseImagesListCsvExportView, self).get_queryset()
+        return self.filter_queryset(queryset)
+
+    def get(self, request, pk=None, format=None):
+        query_set = Resource.objects.select_related('course', 'media_store')
+        course_pk = pk
+        queryset = self.get_queryset()
+        queryset = queryset.filter(course__pk=course_pk).order_by('sort_order')
+        serializer = self.get_serializer(queryset, many=True, context={'request': request})
+        return Response(serializer.data)
 
 
 class CollectionImagesListView(GenericAPIView):

--- a/media_management_api/requirements/base.txt
+++ b/media_management_api/requirements/base.txt
@@ -4,6 +4,7 @@ redis==2.10.3
 django-redis-cache==1.7.1
 hiredis==0.2.0
 djangorestframework==3.9.1
+djangorestframework-csv==2.1.0
 markdown==2.6.11
 mock==1.3.0
 django-filter==1.1.0


### PR DESCRIPTION
This PR resolves [ATGU-2711](https://jira.huit.harvard.edu/browse/ATGU-2711) by:

- Adding a `CsvExportResourceSerializer` which is based on the `ResourceSerializer`.
  - The field requirements are slightly different (needing the iiif_url, and many fewer other fields)
- Adding a `CourseImagesListCsvExportView` which is based on `CourseImagesListView`
  - This view takes the serialized data from  `CsvExportResourceSerializer` at responds with a csv
  - There is no browsable api for this view (reason explained below)
- Adding tests for new view
- Adding the `djangorestframework-csv` package to requirements

## Notes
- There is [an issue](https://github.com/mjumbewu/django-rest-framework-csv/issues/56) with `HyperlinkedIdentityField` appending the request format to the url of the outputted field. Meaning, each url in the output csv has `?format=csv` appended. This is obviously not ideal. Setting `CsvRenderer` as the only renderer eliminates the need to add `?format=csv` to the Get request, and then removes it from the corresponding output.
- `iiif_url = serializers.SerializerMethodField()` implicitly refers to the `get_iiif_url` method, and raises an AssertionError if you explicitly pass the method name as an argument. I find that wild, but we are forced to behave implicitly here.
