### PR TITLE
Add jwts (WIP)

### DIFF
--- a/media_management_api/requirements/base.txt
+++ b/media_management_api/requirements/base.txt
@@ -3,14 +3,15 @@ psycopg2==2.8.4
 redis==2.10.3
 django-redis-cache==1.7.1
 hiredis==0.2.0
-djangorestframework==3.9.1
+djangorestframework~=3.10.0
 djangorestframework-csv==2.1.0
+djangorestframework-simplejwt~=4.6.0
 markdown==2.6.11
 mock==1.3.0
 django-filter==1.1.0
 django-cors-headers==2.2.0
 boto==2.48.0
-pillow==6.2.1
+pillow==8.2.0
 python-magic==0.4.15
 requests==2.21.0
 coverage==5.0

--- a/media_management_api/settings/base.py
+++ b/media_management_api/settings/base.py
@@ -236,6 +236,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
          'rest_framework.authentication.SessionAuthentication',
          'media_management_api.media_auth.authentication.CustomTokenAuthentication',
+         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ),
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }

--- a/media_management_api/urls.py
+++ b/media_management_api/urls.py
@@ -1,12 +1,15 @@
 from django.urls import include, path
 from django.contrib import admin
 from django.views.generic.base import RedirectView
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/auth/', include('media_management_api.media_auth.urls')),
+    path('api/token/', TokenObtainPairView.as_view(), name='token_obtian_pair'),
+    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('api/', include('media_management_api.media_service.urls')),
     path('', RedirectView.as_view(url='/api/', permanent=False), name='index'),
 ]

--- a/media_management_api/urls.py
+++ b/media_management_api/urls.py
@@ -8,7 +8,7 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/auth/', include('media_management_api.media_auth.urls')),
-    path('api/token/', TokenObtainPairView.as_view(), name='token_obtian_pair'),
+    path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('api/', include('media_management_api.media_service.urls')),
     path('', RedirectView.as_view(url='/api/', permanent=False), name='index'),


### PR DESCRIPTION
This PR resolves [ATGU-2932](https://jira.huit.harvard.edu/browse/ATGU-2932) by:

- Bumping the versions of DRF and Pillow
- Adding the [djangorestframework-simplejwt](https://pypi.org/project/djangorestframework-simplejwt/4.6.0/) dependency
- Adding a simplejwt authentication class
- Include simplejwt urls/views for obtain and refreshing tokens

## Blocker
- All blockers resolved

## Notes
- Adding jwt capabilities in this way requires the clients for handling the request/refresh auth flow (probably best done in middleware?)
- You can find example of client requests here: https://django-rest-framework-simplejwt.readthedocs.io/en/latest/getting_started.html#usage