### PR TITLE
JWT auth updates

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">71%</text>
-        <text x="80" y="14">71%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">72%</text>
+        <text x="80" y="14">72%</text>
     </g>
 </svg>

--- a/media_management_api/media_auth/authentication.py
+++ b/media_management_api/media_auth/authentication.py
@@ -39,14 +39,15 @@ class CustomJWTAuthentication(authentication.BaseAuthentication):
     
     def authenticate(self, request):
         jwt = get_access_token_from_request(request, "Bearer ")
-
         if not jwt:
             return None
 
+        logger.debug(f"Attempting to authenticate jwt: {jwt}")
         decoded_token = decode_jwt(jwt)
         if not decoded_token:
-            return None
-        
+            raise exceptions.AuthenticationFailed("JWT authentication failed")
+
         user = UserProfile.get_or_create_profile(decoded_token["user_id"]).user
+        logger.debug(f"Authenticated user {user} with jwt: {jwt}")
         
         return (user, None)

--- a/media_management_api/media_auth/services.py
+++ b/media_management_api/media_auth/services.py
@@ -27,6 +27,10 @@ def get_client_key(header):
         return False
 
 
+def has_required_data(token, data):
+    return all([k in token for k in data])
+
+
 def decode_jwt(token):
     required_claims = ["iat", "exp", "user_id", "client_id"]
     algorithms = ["HS256"]

--- a/media_management_api/media_auth/services.py
+++ b/media_management_api/media_auth/services.py
@@ -35,7 +35,7 @@ def decode_jwt(token):
     # We only read the unverified token to get the "client_id" in order to successfully verify later.
     # A token should not be trusted unless the signiture is verified.
     unverified_token = jwt.decode(token, options={"verify_signature":False})
-    if not has_required_data(unverified_token, ("client_id", "course_id", "user_id", "course_permission")):
+    if not has_required_data(unverified_token, ("client_id", "user_id")):
         return False
     key = get_client_key(unverified_token)
     if key:
@@ -43,14 +43,14 @@ def decode_jwt(token):
             decoded = jwt.decode(token, key, algorithms=["HS256"])
             return decoded
         except jwt.exceptions.InvalidSignatureError:
-            logger.debug(f"Invalid signature for Token {unverified_token}")
+            logger.error(f"Invalid signature for jwt: {unverified_token}")
             return False
     return False
 
 
 def get_course_user(token):
     user = get_or_create_user(token["user_id"])
-    add_user_to_course(user=user, course_id=token["course_id"], is_admin=token["course_permission"] == "write")
+    add_user_to_course(user=user, course_id=token["course_id"], is_admin=token.get("course_permission") == "write")
     return user
 
 

--- a/media_management_api/media_auth/tests/test_services.py
+++ b/media_management_api/media_auth/tests/test_services.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 import unittest
 import jwt
 
@@ -5,7 +6,6 @@ from ..models import Application
 from media_management_api.media_service.models import Course, CourseUser
 from ..services import (
     get_client_key,
-    has_required_data,
     decode_jwt,
     get_course_user
     )
@@ -31,18 +31,12 @@ class JWTAuthTest(unittest.TestCase):
         header = {"client_id": "does not exist"}
         self.assertEqual(get_client_key(header), False)
 
-    def test_has_required_data(self):
-        data_to_check_for = ("a", "b", "c")
-        data_to_check_in = {"a":1, "b":1, "c":1, "d":1}
-        self.assertEqual(has_required_data(data_to_check_in, data_to_check_for), True)
-
-    def test_has_required_data_fail(self):
-        data_to_check_for = ("a", "b", "c")
-        data_to_check_in = {"a":1, "d":1}
-        self.assertEqual(has_required_data(data_to_check_in, data_to_check_for), False)
-
     def test_decode_jwt(self):
+        issued_at = datetime.utcnow()
+        expiration = issued_at + timedelta(seconds=60)
         test_payload = {
+            "iat": int(issued_at.timestamp()),
+            "exp": int(expiration.timestamp()),
             "client_id": "test",
             "course_id": 178,
             "user_id": 12345,
@@ -52,8 +46,35 @@ class JWTAuthTest(unittest.TestCase):
         decoded_jwt = decode_jwt(test_jwt)
         self.assertEqual(decoded_jwt, test_payload)
 
+    def test_decode_jwt_missing_expiration(self):
+        test_payload = {
+            "iat": datetime.utcnow(),
+            "client_id": "test",
+            "course_id": 178,
+            "user_id": 12345,
+            "course_permission": "read"
+        }
+        test_jwt = jwt.encode(test_payload, "secret", algorithm="HS256")
+        decoded_jwt = decode_jwt(test_jwt)
+        self.assertEqual(decoded_jwt, False)
+
+    def test_decode_jwt_expired(self):
+        test_payload = {
+            "iat": datetime.utcnow(),
+            "exp": datetime.utcnow() - timedelta(seconds=120),
+            "client_id": "test",
+            "course_id": 178,
+            "user_id": 12345,
+            "course_permission": "read"
+        }
+        test_jwt = jwt.encode(test_payload, "secret", algorithm="HS256")
+        decoded_jwt = decode_jwt(test_jwt)
+        self.assertEqual(decoded_jwt, False)
+
     def test_decode_jwt_unregistered_client(self):
         test_payload = {
+            "iat": datetime.utcnow(),
+            "exp": datetime.utcnow() + timedelta(seconds=60),
             "client_id": "not registered",
             "course_id": 178,
             "user_id": 12345,
@@ -65,6 +86,8 @@ class JWTAuthTest(unittest.TestCase):
 
     def test_decode_jwt_bad_secret(self):
         test_payload = {
+            "iat": datetime.utcnow(),
+            "exp": datetime.utcnow() + timedelta(seconds=60),
             "client_id": "test",
             "course_id": 178,
             "user_id": 12345,

--- a/media_management_api/media_auth/tests/test_services.py
+++ b/media_management_api/media_auth/tests/test_services.py
@@ -6,6 +6,7 @@ from ..models import Application
 from media_management_api.media_service.models import Course, CourseUser
 from ..services import (
     get_client_key,
+    has_required_data,
     decode_jwt,
     get_course_user
     )
@@ -30,6 +31,16 @@ class JWTAuthTest(unittest.TestCase):
     def test_get_client_key_no_client_id(self):
         header = {"client_id": "does not exist"}
         self.assertEqual(get_client_key(header), False)
+
+    def test_has_required_data(self):
+        data_to_check_for = ("a", "b", "c")
+        data_to_check_in = {"a":1, "b":1, "c":1, "d":1}
+        self.assertEqual(has_required_data(data_to_check_in, data_to_check_for), True)
+
+    def test_has_required_data_fail(self):
+        data_to_check_for = ("a", "b", "c")
+        data_to_check_in = {"a":1, "d":1}
+        self.assertEqual(has_required_data(data_to_check_in, data_to_check_for), False)
 
     def test_decode_jwt(self):
         issued_at = datetime.utcnow()

--- a/media_management_api/media_auth/tests/test_views.py
+++ b/media_management_api/media_auth/tests/test_views.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from django.test import TestCase
 import jwt
 
@@ -17,6 +18,8 @@ class TestAuthViews(TestCase):
     
     def test_update_user_with_new_user(self):
         test_payload = {
+            "iat": datetime.utcnow(),
+            "exp": datetime.utcnow() + timedelta(seconds=60),
             "client_id": "test",
             "course_id": self.course.pk,
             "user_id": 9999,
@@ -35,6 +38,8 @@ class TestAuthViews(TestCase):
 
     def test_update_user_write_permission(self):
         write_payload = {
+            "iat": datetime.utcnow(),
+            "exp": datetime.utcnow() + timedelta(seconds=60),
             "client_id": "test",
             "course_id": self.course.pk,
             "user_id": 9999,
@@ -51,6 +56,8 @@ class TestAuthViews(TestCase):
 
     def test_update_user_course_does_not_exist(self):
         payload = {
+            "iat": datetime.utcnow(),
+            "exp": datetime.utcnow() + timedelta(seconds=60),
             "client_id": "test",
             "course_id": 5,
             "user_id": 9999,
@@ -61,20 +68,20 @@ class TestAuthViews(TestCase):
             "HTTP_AUTHORIZATION": f"Bearer {test_jwt}"
         }
         response = self.client.post("/api/auth/authorize-user", **headers)
-        # course does not exist, so it is a bad request
-        self.assertEqual(response.status_code, 400)
+        # JWT is valid, but course does not exist, so return 404
+        self.assertEqual(response.status_code, 404)
 
-    def test_update_user_payload_not_complete(self):
+    def test_update_user_payload_missing_user_id(self):
         payload = {
+            "iat": datetime.utcnow(),
+            "exp": datetime.utcnow() + timedelta(seconds=60),
             "client_id": "test",
-            "course_id": self.course.pk,
-            "user_id": 9999,
         }
         test_jwt = jwt.encode(payload, "secret", algorithm="HS256")
         headers = {
             "HTTP_AUTHORIZATION": f"Bearer {test_jwt}"
         }
         response = self.client.post("/api/auth/authorize-user", **headers)
-        # course_permission is missing, so it is a bad request
+        # user_id is missing, so it is a bad request
         self.assertEqual(response.status_code, 400)
 

--- a/media_management_api/media_auth/views.py
+++ b/media_management_api/media_auth/views.py
@@ -60,22 +60,22 @@ def destroy_token(request, access_token):
 def authorize_user(request):
     jwt = services.get_access_token_from_request(request, "Bearer ")
     if not jwt:
-        logger.error("JWT missing from authorization header")
+        logger.warning("JWT missing from authorization header")
         return HttpResponseBadRequest("Not able to get JWT from request")
 
     decoded_token = services.decode_jwt(jwt)
     if not decoded_token:
-        logger.error(f"JWT decode failed: {jwt}")
+        logger.warning(f"JWT decode failed: {jwt}")
         return HttpResponseBadRequest("Unable to verify the JWT")
 
     if "course_id" not in decoded_token:
-        logger.error(f"JWT missing course_id: {decoded_token}")
+        logger.warning(f"JWT missing course_id: {decoded_token}")
         return HttpResponseBadRequest("Missing course ID from token")
 
     try:
         services.get_course_user(decoded_token) # strange name for this function
     except InvalidTokenError:
-        logger.error(f"JWT failed to authorize user because course does not exist")
+        logger.warning(f"JWT failed to authorize user because course does not exist")
         return HttpResponseNotFound("Course not found")
 
     logger.info(f"Authorized user: {decoded_token}")

--- a/media_management_api/media_auth/views.py
+++ b/media_management_api/media_auth/views.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.http import HttpResponse, HttpResponseNotFound, HttpResponseBadRequest
+from django.http import HttpResponse, HttpResponseNotFound, HttpResponseBadRequest, JsonResponse
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.decorators import user_passes_test
 from django.views.decorators.http import require_http_methods
@@ -78,4 +78,4 @@ def authorize_user(request):
         logger.error(f"JWT failed to authorize user because course does not exist")
         return HttpResponseNotFound("Course not found")
 
-    return HttpResponse({"success": True}, status=200, content_type="application/json")
+    return JsonResponse({"success": True})

--- a/media_management_api/media_auth/views.py
+++ b/media_management_api/media_auth/views.py
@@ -78,4 +78,5 @@ def authorize_user(request):
         logger.error(f"JWT failed to authorize user because course does not exist")
         return HttpResponseNotFound("Course not found")
 
+    logger.info(f"Authorized user: {decoded_token}")
     return JsonResponse({"success": True})

--- a/media_management_api/media_auth/views.py
+++ b/media_management_api/media_auth/views.py
@@ -60,22 +60,22 @@ def destroy_token(request, access_token):
 def authorize_user(request):
     jwt = services.get_access_token_from_request(request, "Bearer ")
     if not jwt:
-        logger.error("authorize_user: jwt missing from authorization header")
+        logger.error("JWT missing from authorization header")
         return HttpResponseBadRequest("Not able to get JWT from request")
 
     decoded_token = services.decode_jwt(jwt)
     if not decoded_token:
-        logger.error(f"authorize_user: jwt decode failed: {jwt}")
+        logger.error(f"JWT decode failed: {jwt}")
         return HttpResponseBadRequest("Unable to verify the JWT")
 
     if "course_id" not in decoded_token:
-        logger.error(f"authorize_user: decoded token missing course_id: {decoded_token}")
+        logger.error(f"JWT missing course_id: {decoded_token}")
         return HttpResponseBadRequest("Missing course ID from token")
 
     try:
         services.get_course_user(decoded_token) # strange name for this function
     except InvalidTokenError:
-        logger.error(f"authorize_user: jwt course does not exist: {jwt}")
-        return HttpResponseNotFound("Course does not exist")
+        logger.error(f"JWT failed to authorize user because course does not exist")
+        return HttpResponseNotFound("Course not found")
 
     return HttpResponse({"success": True}, status=200, content_type="application/json")


### PR DESCRIPTION
This PR makes a few tweaks to the JWT auth based on testing with the SDK.

Changes:
- Added check for JWT expiration.
- Consolidated the exception handling and logging around decoding JWTs. 
- Made the `course_id` and `course_permission` claims optional since they won't be known if the course does not exist yet. 
- Removed CSRF protection from the `authorize_user` view and tweaked the responses slightly (missing course now returns 404, and a successful authorization returns a 200 `JsonResponse`).

Additional notes:
- I successfully tested the JWT updates with `hxat` (AnnotationsX) as a client application. 
- As expected, the existing `obtain-token` auth continues to work just fine, so the client can make the switch to JWTs when ready.