### PR TITLE
Restore aws.txt requirements file 

### DIFF
--- a/media_management_api/requirements/aws.txt
+++ b/media_management_api/requirements/aws.txt
@@ -1,0 +1,1 @@
+requirements.txt

--- a/media_management_api/requirements/aws.txt
+++ b/media_management_api/requirements/aws.txt
@@ -1,1 +1,1 @@
-requirements.txt
+../../requirements.txt


### PR DESCRIPTION
This PR restores the `media_management_api/requirements/aws.txt` file since it is still needed for our existing (legacy) deployment process. It's just a symlink to the project root's `requirements.txt`. 